### PR TITLE
Fix .eslintrc JSON

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,7 @@
 		"no-unused-vars": "off",
 		"no-console": ["warn"],
 		"no-extra-boolean-cast": ["off"],
-		"no-control-regex": ["off"],
+                "no-control-regex": ["off"]
 	},
 	"root": true,
 	"globals": {


### PR DESCRIPTION
## Summary
- remove the trailing comma from `"no-control-regex"` rule

## Testing
- `pre-commit run --files .eslintrc`
- `npx -y eslint@8 --print-config test.js`

------
https://chatgpt.com/codex/tasks/task_e_6840fa99e28483288b1d496f1338f9e2