### PR TITLE
Fix missing website attribute for Instrument Profile

### DIFF
--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
@@ -7,6 +7,17 @@ import frappe
 from frappe.model.document import Document
 
 class InstrumentProfile(Document):
+    """Server side logic for the Instrument Profile DocType."""
+
+    #: configuration used by Frappe's website renderer
+    website = frappe._dict(
+        # the field that controls whether the record should be shown on the website
+        # all instrument profiles are considered published when they exist
+        condition_field="name",
+        # use the instrument's serial number as the web page title
+        page_title_field="serial_number",
+    )
+
     def validate(self):
         if self.acquisition_type == "Customer" and not self.customer:
             frappe.throw("Customer is required for customer-owned instruments.")

--- a/repair_portal/instrument_setup/doctype/instrument_profile/instrument_profile.py
+++ b/repair_portal/instrument_setup/doctype/instrument_profile/instrument_profile.py
@@ -9,4 +9,10 @@ import frappe
 from frappe.model.document import Document
 
 class InstrumentProfile(Document):
-    pass
+    """Lightweight controller for Instrument Profile."""
+
+    #: configuration for Frappe website rendering
+    website = frappe._dict(
+        condition_field="name",
+        page_title_field="serial_number",
+    )


### PR DESCRIPTION
## Summary
- define `website` settings for InstrumentProfile DocType

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_684d130c2ee88328acebd4b108f4311c