### PR TITLE
Add Pulse Update real-time feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@
 - Controller and JSON schema included for Instrument Category.
 - Ensured all files present per Frappe v15 convention.
 - Ready for migration.
+
+### 2025-07-01
+- Added Pulse Update feature with real-time repair tracking.
+
+
+## Enabling Pulse Update Feature
+1. Run `bench migrate` to apply new DocTypes.
+2. Use `/repair_pulse?name=REQ-0001` to view live updates.
+3. Technicians call `pulse_update.create_update` API to post progress.

--- a/repair_portal/public/js/pulse_stream.js
+++ b/repair_portal/public/js/pulse_stream.js
@@ -1,0 +1,30 @@
+frappe.ready(() => {
+  const updatesEl = document.querySelector('#pulse-updates');
+  if (!updatesEl) return;
+  const channel = updatesEl.dataset.channel;
+
+  function addRow(data) {
+    const li = document.createElement('li');
+    li.className = 'py-2 border-t';
+    li.innerHTML = `<strong>${data.status || ''}</strong> <span class="ml-2 text-gray-600">${data.update_time}</span>`;
+    if (data.details) {
+      const p = document.createElement('p');
+      p.className = 'text-sm';
+      p.textContent = data.details;
+      li.appendChild(p);
+    }
+    if (data.percent_complete) {
+      const pc = document.createElement('p');
+      pc.className = 'text-xs text-green-700';
+      pc.textContent = `${data.percent_complete}%`;
+      li.appendChild(pc);
+      if (Number(data.percent_complete) === 100 && window.confetti) {
+        window.confetti();
+      }
+    }
+    updatesEl.appendChild(li);
+  }
+
+  (window.initialUpdates || []).forEach(addRow);
+  frappe.realtime.on(channel, addRow);
+});

--- a/repair_portal/repair_portal/doctype/pulse_update/pulse_update.json
+++ b/repair_portal/repair_portal/doctype/pulse_update/pulse_update.json
@@ -1,0 +1,19 @@
+{
+  "doctype": "DocType",
+  "name": "Pulse Update",
+  "module": "Repair Portal",
+  "custom": 0,
+  "istable": 0,
+  "editable_grid": 1,
+  "fields": [
+    {"fieldname": "repair_request", "label": "Repair Request", "fieldtype": "Link", "options": "Repair Request", "reqd": 1},
+    {"fieldname": "update_time", "label": "Update Time", "fieldtype": "Datetime", "default": "now", "reqd": 1},
+    {"fieldname": "status", "label": "Status", "fieldtype": "Data"},
+    {"fieldname": "details", "label": "Details", "fieldtype": "Small Text"},
+    {"fieldname": "percent_complete", "label": "Percent Complete", "fieldtype": "Int"}
+  ],
+  "permissions": [
+    {"role": "Technician", "read": 1, "write": 1, "create": 1},
+    {"role": "Client", "read": 1}
+  ]
+}

--- a/repair_portal/repair_portal/doctype/pulse_update/pulse_update.py
+++ b/repair_portal/repair_portal/doctype/pulse_update/pulse_update.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+
+class PulseUpdate(Document):
+    pass
+
+
+@frappe.whitelist(allow_guest=False, methods=["POST"])
+def create_update(repair_request: str, status: str | None = None, details: str | None = None, percent_complete: int | None = None):
+    """Create a new Pulse Update and notify viewers in real time."""
+    frappe.only_for("Technician")
+
+    doc = frappe.get_doc({
+        "doctype": "Pulse Update",
+        "repair_request": repair_request,
+        "status": status,
+        "details": details,
+        "percent_complete": percent_complete,
+    })
+    doc.insert()
+
+    frappe.publish_realtime(f"repair_pulse_{repair_request}", doc.as_dict())
+    return doc.name

--- a/repair_portal/repair_portal/www/repair_pulse.html
+++ b/repair_portal/repair_portal/www/repair_pulse.html
@@ -1,0 +1,32 @@
+{% extends "templates/web.html" %}
+
+{% block title %}{{ _("Repair Pulse") }}{% endblock %}
+
+{% block page_content %}
+<div class="container my-8">
+  <h1 class="text-3xl font-semibold mb-6">{{ _("Repair Pulse") }}</h1>
+  <ul id="pulse-updates" data-channel="{{ channel }}" class="divide-y">
+    {% for u in updates %}
+    <li class="py-2">
+      <strong>{{ u.status }}</strong>
+      <span class="ml-2 text-gray-600">{{ frappe.format(u.update_time, 'Datetime') }}</span>
+      {% if u.details %}
+      <p class="text-sm">{{ u.details }}</p>
+      {% endif %}
+      {% if u.percent_complete %}
+      <p class="text-xs text-green-700">{{ u.percent_complete }}%</p>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+<script>
+  window.initialUpdates = {{ updates_json | safe }};
+</script>
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+<script src="/assets/repair_portal/js/pulse_stream.js"></script>
+{% endblock %}

--- a/repair_portal/repair_portal/www/repair_pulse.py
+++ b/repair_portal/repair_portal/www/repair_pulse.py
@@ -1,0 +1,29 @@
+import frappe
+from frappe import _
+
+login_required = True
+
+
+def get_context(context):
+    frappe.only_for(("Client", "Technician"))
+    name = frappe.form_dict.get("name")
+    if not name:
+        frappe.throw(_("Repair Request not specified"))
+
+    doc = frappe.get_doc("Repair Request", name)
+    user = frappe.session.user
+    if "Technician" not in frappe.get_roles(user) and doc.customer != user:
+        frappe.throw(_("Not permitted"))
+
+    updates = frappe.get_all(
+        "Pulse Update",
+        fields=["name", "update_time", "status", "details", "percent_complete"],
+        filters={"repair_request": name},
+        order_by="update_time asc",
+    )
+
+    context.repair_request = doc
+    context.updates = updates
+    context.updates_json = frappe.safe_json.dumps(updates)
+    context.channel = f"repair_pulse_{name}"
+    return context

--- a/repair_portal/test/test_pulse_update.py
+++ b/repair_portal/test/test_pulse_update.py
@@ -1,0 +1,22 @@
+import unittest
+
+import frappe
+
+from repair_portal.repair_portal.doctype.pulse_update import pulse_update
+
+
+class TestPulseUpdateAPI(unittest.TestCase):
+    def test_create_update(self):
+        frappe.set_user("Administrator")
+        req = frappe.get_doc({
+            "doctype": "Repair Request",
+            "customer": "test@example.com",
+            "issue_description": "test issue",
+        }).insert()
+        name = pulse_update.create_update(
+            repair_request=req.name,
+            status="Init",
+            details="Started",
+            percent_complete=10,
+        )
+        assert frappe.db.exists("Pulse Update", name)


### PR DESCRIPTION
## Summary
- create Pulse Update DocType with real-time updates
- add repair_pulse web page and JS for live feed with confetti
- expose API to create updates
- document feature
- add unit test

## Testing
- `ruff check repair_portal/repair_portal/doctype/pulse_update/pulse_update.py`
- `ruff check repair_portal/repair_portal/www/repair_pulse.py`
- `ruff check repair_portal/test/test_pulse_update.py`
- `pytest repair_portal/test/test_pulse_update.py -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68535f087c6483289d14a57c62d0e277