### PR TITLE
Add ClariCare Dashboard

### DIFF
--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
@@ -7,91 +7,21 @@
   "editable_grid": 1,
   "standard": 1,
   "fields": [
-    {
-      "fieldname": "instrument_category",
-      "label": "Instrument Category",
-      "fieldtype": "Select",
-      "options": "Clarinet\nSaxophone\nFlute"
-    },
-    {
-      "fieldname": "brand",
-      "label": "Brand",
-      "fieldtype": "Link",
-      "options": "Brand"
-    },
-    {
-      "fieldname": "model",
-      "label": "Model",
-      "fieldtype": "Data"
-    },
-    {
-      "fieldname": "serial_number",
-      "label": "Serial Number",
-      "fieldtype": "Data",
-      "unique": 1,
-      "reqd": 1
-    },
-    {
-      "fieldname": "owner",
-      "label": "Owner",
-      "fieldtype": "Link",
-      "options": "Customer"
-    },
-    {
-      "fieldname": "client_profile",
-      "label": "Client Profile",
-      "fieldtype": "Link",
-      "options": "Client Profile"
-    },
-    {
-      "fieldname": "photo",
-      "label": "Photo",
-      "fieldtype": "Attach Image"
-    },
-    {
-      "fieldname": "qr_code_svg",
-      "label": "QR Code",
-      "fieldtype": "HTML",
-      "read_only": 1
-    },
-    {
-      "fieldname": "last_service_date",
-      "label": "Last Service Date",
-      "fieldtype": "Date",
-      "read_only": 1
-    },
-    {
-      "fieldname": "wellness_score",
-      "label": "Wellness Score",
-      "fieldtype": "Int",
-      "default": 0
-    },
-    {
-      "fieldname": "clarinet_pad_map",
-      "label": "Pad Map View",
-      "fieldtype": "HTML",
-      "depends_on": "eval:doc.instrument_category=='Clarinet'"
-    },
-    {
-      "fieldname": "route",
-      "label": "Route",
-      "fieldtype": "Data",
-      "reqd": 1
-    },
-    {
-      "fieldname": "published",
-      "label": "Published",
-      "fieldtype": "Check",
-      "default": 1
-    }
+    {"fieldname": "instrument_category", "label": "Instrument Category", "fieldtype": "Select", "options": "Clarinet\nSaxophone\nFlute"},
+    {"fieldname": "brand", "label": "Brand", "fieldtype": "Link", "options": "Brand"},
+    {"fieldname": "model", "label": "Model", "fieldtype": "Data"},
+    {"fieldname": "serial_number", "label": "Serial Number", "fieldtype": "Data", "unique": 1, "reqd": 1},
+    {"fieldname": "owner", "label": "Owner", "fieldtype": "Link", "options": "Customer"},
+    {"fieldname": "client_profile", "label": "Client Profile", "fieldtype": "Link", "options": "Client Profile"},
+    {"fieldname": "photo", "label": "Photo", "fieldtype": "Attach Image"},
+    {"fieldname": "qr_code_svg", "label": "QR Code", "fieldtype": "HTML", "read_only": 1},
+    {"fieldname": "last_service_date", "label": "Last Service Date", "fieldtype": "Date", "read_only": 1},
+    {"fieldname": "wellness_score", "label": "Wellness Score", "fieldtype": "Int", "default": 0},
+    {"fieldname": "clarinet_pad_map", "label": "Pad Map View", "fieldtype": "HTML", "depends_on": "eval:doc.instrument_category=='Clarinet'"},
+    {"fieldname": "route", "label": "Route", "fieldtype": "Data", "reqd": 1},
+    {"fieldname": "published", "label": "Published", "fieldtype": "Check", "default": 1}
   ],
   "permissions": [
-    {
-      "role": "System Manager",
-      "read": 1,
-      "write": 1,
-      "create": 1,
-      "delete": 1
-    }
+    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1}
   ]
 }

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
@@ -7,20 +7,91 @@
   "editable_grid": 1,
   "standard": 1,
   "fields": [
-    {"fieldname": "instrument_category", "label": "Instrument Category", "fieldtype": "Select", "options": "Clarinet\nSaxophone\nFlute"},
-    {"fieldname": "brand", "label": "Brand", "fieldtype": "Link", "options": "Brand"},
-    {"fieldname": "model", "label": "Model", "fieldtype": "Data"},
-    {"fieldname": "serial_number", "label": "Serial Number", "fieldtype": "Data", "unique": 1, "reqd": 1},
-    {"fieldname": "owner", "label": "Owner", "fieldtype": "Link", "options": "Customer"},
-    {"fieldname": "client_profile", "label": "Client Profile", "fieldtype": "Link", "options": "Client Profile"},
-    {"fieldname": "photo", "label": "Photo", "fieldtype": "Attach Image"},
-    {"fieldname": "qr_code_svg", "label": "QR Code", "fieldtype": "HTML", "read_only": 1},
-    {"fieldname": "last_service_date", "label": "Last Service Date", "fieldtype": "Date", "read_only": 1},
-    {"fieldname": "clarinet_pad_map", "label": "Pad Map View", "fieldtype": "HTML", "depends_on": "eval:doc.instrument_category=='Clarinet'"},
-    {"fieldname": "route", "label": "Route", "fieldtype": "Data", "reqd": 1},
-    {"fieldname": "published", "label": "Published", "fieldtype": "Check", "default": 1}
+    {
+      "fieldname": "instrument_category",
+      "label": "Instrument Category",
+      "fieldtype": "Select",
+      "options": "Clarinet\nSaxophone\nFlute"
+    },
+    {
+      "fieldname": "brand",
+      "label": "Brand",
+      "fieldtype": "Link",
+      "options": "Brand"
+    },
+    {
+      "fieldname": "model",
+      "label": "Model",
+      "fieldtype": "Data"
+    },
+    {
+      "fieldname": "serial_number",
+      "label": "Serial Number",
+      "fieldtype": "Data",
+      "unique": 1,
+      "reqd": 1
+    },
+    {
+      "fieldname": "owner",
+      "label": "Owner",
+      "fieldtype": "Link",
+      "options": "Customer"
+    },
+    {
+      "fieldname": "client_profile",
+      "label": "Client Profile",
+      "fieldtype": "Link",
+      "options": "Client Profile"
+    },
+    {
+      "fieldname": "photo",
+      "label": "Photo",
+      "fieldtype": "Attach Image"
+    },
+    {
+      "fieldname": "qr_code_svg",
+      "label": "QR Code",
+      "fieldtype": "HTML",
+      "read_only": 1
+    },
+    {
+      "fieldname": "last_service_date",
+      "label": "Last Service Date",
+      "fieldtype": "Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "wellness_score",
+      "label": "Wellness Score",
+      "fieldtype": "Int",
+      "default": 0
+    },
+    {
+      "fieldname": "clarinet_pad_map",
+      "label": "Pad Map View",
+      "fieldtype": "HTML",
+      "depends_on": "eval:doc.instrument_category=='Clarinet'"
+    },
+    {
+      "fieldname": "route",
+      "label": "Route",
+      "fieldtype": "Data",
+      "reqd": 1
+    },
+    {
+      "fieldname": "published",
+      "label": "Published",
+      "fieldtype": "Check",
+      "default": 1
+    }
   ],
   "permissions": [
-    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1}
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
+    }
   ]
 }

--- a/repair_portal/public/js/wellness_dashboard.js
+++ b/repair_portal/public/js/wellness_dashboard.js
@@ -1,0 +1,60 @@
+frappe.ready(() => {
+  const root = document.getElementById('wellness-app');
+  if (!root) return;
+  const { createApp } = Vue;
+
+  createApp({
+    data() {
+      return {
+        score: Number(root.dataset.score || 0),
+        history: JSON.parse(root.dataset.history || '[]'),
+        dueDays: root.dataset.dueDays ? Number(root.dataset.dueDays) : null,
+      };
+    },
+    mounted() {
+      this.drawGauge();
+      this.renderHistory();
+      if (this.history.length && window.confetti) {
+        window.confetti({ particleCount: 40, spread: 60 });
+      }
+      if (this.dueDays !== null && this.dueDays <= 30) {
+        const badge = document.getElementById('due-badge');
+        badge?.classList.remove('hidden');
+        badge?.classList.add('animate-pulse');
+      }
+    },
+    methods: {
+      drawGauge() {
+        const ctx = document.getElementById('gauge').getContext('2d');
+        const color = this.score > 70 ? '#16a34a' : this.score > 40 ? '#facc15' : '#dc2626';
+        new Chart(ctx, {
+          type: 'doughnut',
+          data: {
+            datasets: [
+              {
+                data: [this.score, 100 - this.score],
+                backgroundColor: [color, '#e5e7eb'],
+                borderWidth: 0,
+              },
+            ],
+          },
+          options: {
+            circumference: 180,
+            rotation: 270,
+            cutout: '70%',
+            plugins: { tooltip: { enabled: false }, legend: { display: false } },
+          },
+        });
+      },
+      renderHistory() {
+        const list = document.getElementById('service-history');
+        this.history.forEach((item) => {
+          const li = document.createElement('li');
+          li.className = 'py-2';
+          li.innerHTML = `<strong>${item.repair_type}</strong> <span class="ml-2 text-gray-600">${item.modified}</span>`;
+          list.appendChild(li);
+        });
+      },
+    },
+  }).mount('#wellness-app');
+});

--- a/repair_portal/templates/pages/instrument_wellness.html
+++ b/repair_portal/templates/pages/instrument_wellness.html
@@ -1,0 +1,31 @@
+{% extends "templates/web.html" %}
+
+{% block title %}{{ _("Instrument Wellness") }}{% endblock %}
+
+{% block page_content %}
+<div class="container my-8">
+  <h1 class="text-3xl font-semibold mb-6">{{ instrument.instrument_name }}</h1>
+  <div id="wellness-app"
+       data-score="{{ wellness_score }}"
+       data-history="{{ service_logs_json | escape }}"
+       data-due-days="{{ due_days }}">
+    <canvas id="gauge" width="300" height="150"></canvas>
+    <div class="mt-4">
+      <button id="schedule-btn" class="btn btn-primary"
+              onclick="location.href='/repair_request?instrument={{ instrument.name }}'">
+        {{ _("Schedule Next Service") }}
+      </button>
+      <span id="due-badge" class="badge bg-warning ml-2 hidden">{{ _("Service Due Soon") }}</span>
+    </div>
+    <ul id="service-history" class="mt-6 divide-y"></ul>
+  </div>
+</div>
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/vue@3.4.0/dist/vue.global.prod.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+<script src="/assets/repair_portal/js/wellness_dashboard.js"></script>
+{% endblock %}

--- a/repair_portal/test/test_instrument_wellness.py
+++ b/repair_portal/test/test_instrument_wellness.py
@@ -1,0 +1,23 @@
+import unittest
+
+import frappe
+
+
+class TestInstrumentWellness(unittest.TestCase):
+    def test_page_context(self):
+        frappe.set_user("Administrator")
+        inst = frappe.get_doc(
+            {
+                "doctype": "Instrument Profile",
+                "instrument_category": "Clarinet",
+                "serial_number": "TEST123",
+                "brand": "TestBrand",
+                "route": "test-inst",
+            }
+        ).insert()
+        context = frappe._dict()
+        frappe.local.form_dict = {"name": inst.name}
+        from repair_portal.www import instrument_wellness
+
+        instrument_wellness.get_context(context)
+        assert context.instrument.name == inst.name

--- a/repair_portal/www/instrument_wellness.py
+++ b/repair_portal/www/instrument_wellness.py
@@ -1,0 +1,44 @@
+"""Show wellness dashboard for a specific instrument."""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+from frappe.utils import add_days, getdate, nowdate
+
+login_required = True
+
+
+def get_context(context):
+    """Build context for instrument wellness dashboard."""
+    frappe.only_for(("Client", "Technician"))
+    name = frappe.form_dict.get("name")
+    if not name:
+        frappe.throw(_("Instrument not specified"))
+
+    instrument = frappe.get_doc("Instrument Profile", name)
+    user = frappe.session.user
+    if "Technician" not in frappe.get_roles(user):
+        client = frappe.db.get_value("Client Profile", {"linked_user": user}, "name")
+        if instrument.client_profile != client and instrument.owner != user:
+            frappe.throw(_("Not permitted"))
+
+    logs = frappe.get_all(
+        "Clarinet Repair Log",
+        filters={"clarinet_serial_number": instrument.serial_number},
+        fields=["name", "repair_type", "modified"],
+        order_by="modified desc",
+    )
+
+    wellness_score = instrument.wellness_score or 0
+    due_days = None
+    if instrument.last_service_date:
+        next_due = add_days(instrument.last_service_date, 180)
+        due_days = (getdate(next_due) - getdate(nowdate())).days
+
+    context.instrument = instrument
+    context.wellness_score = wellness_score
+    context.service_logs = logs
+    context.service_logs_json = frappe.safe_json.dumps(logs)
+    context.due_days = due_days
+    return context


### PR DESCRIPTION
## Summary
- extend Instrument Profile with `wellness_score`
- add ClariCare Dashboard controller, template, and JS
- include basic unit test for the new page

## Testing
- `ruff check repair_portal/www/instrument_wellness.py repair_portal/test/test_instrument_wellness.py`
- `black repair_portal/www/instrument_wellness.py repair_portal/test/test_instrument_wellness.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6853cc7502b0832886ef8d58185a60eb