### PR TITLE
Finalize lab module API and tests

### DIFF
--- a/repair_portal/hooks.py
+++ b/repair_portal/hooks.py
@@ -7,6 +7,9 @@ app_license = "MIT"
 
 app_include_js = [
     "/assets/repair_portal/lab_bundle.js",
+    "https://cdn.jsdelivr.net/npm/plotly.js-dist@2.26.0/plotly.min.js",
+    "https://cdn.jsdelivr.net/npm/meyda/dist/web/meyda.min.js",
+    "https://cdn.jsdelivr.net/npm/tone/build/Tone.min.js",
 ]
 
 website_generators = [

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.js
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.js
@@ -1,22 +1,26 @@
 frappe.ui.form.on('Instrument Profile', {
-  refresh: function(frm) {
-    if (frappe.user_roles.includes("System Manager")) {
-      frm.add_custom_button("Renew Warranty", () => {
-        frappe.prompt([
-          { fieldname: 'new_start_date', label: 'New Start Date', fieldtype: 'Date', reqd: 1 },
-          { fieldname: 'new_end_date', label: 'New End Date', fieldtype: 'Date', reqd: 1 },
-          { fieldname: 'reason', label: 'Reason for Renewal', fieldtype: 'Data', reqd: 1 },
-        ], values => {
-          frm.set_value('warranty_start_date', values.new_start_date);
-          frm.set_value('warranty_end_date', values.new_end_date);
-          frm.set_value('warranty_modification_reason', values.reason);
-          frm.save();
-        }, 'Renew Warranty');
+  refresh(frm) {
+    if (frappe.user_roles.includes('System Manager')) {
+      frm.add_custom_button('Renew Warranty', () => {
+        frappe.prompt(
+          [
+            { fieldname: 'new_start_date', label: 'New Start Date', fieldtype: 'Date', reqd: 1 },
+            { fieldname: 'new_end_date', label: 'New End Date', fieldtype: 'Date', reqd: 1 },
+            { fieldname: 'reason', label: 'Reason for Renewal', fieldtype: 'Data', reqd: 1 },
+          ],
+          (values) => {
+            frm.set_value('warranty_start_date', values.new_start_date);
+            frm.set_value('warranty_end_date', values.new_end_date);
+            frm.set_value('warranty_modification_reason', values.reason);
+            frm.save();
+          },
+          'Renew Warranty'
+        );
       });
     }
 
-    frm.add_custom_button("View Lab Data", () => {
-      frappe.set_route('List', 'Impedance Snapshot', { instrument: frm.doc.name });
+    frm.add_custom_button('View Lab Data', () => {
+      frappe.set_route('lab-dashboard', { instrument: frm.doc.name });
     });
-  }
+  },
 });

--- a/repair_portal/lab/api.py
+++ b/repair_portal/lab/api.py
@@ -1,25 +1,137 @@
-"""Server-side API methods for Lab module."""
+# File: repair_portal/lab/api.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Server-side API methods for Lab module.
 
 from __future__ import annotations
 
 import frappe
 
 
-def save_impedance_snapshot(instrument: str, session_type: str, raw_data: str) -> dict:
-    """Create an Impedance Snapshot with one peak entry.
+def _parse_json(data: str) -> list[dict]:
+    try:
+        return frappe.parse_json(data) or []
+    except Exception:  # pragma: no cover - parse errors logged
+        frappe.log_error(frappe.get_traceback(), 'Lab API JSON Parse Error')
+        return []
 
-    Args:
-        instrument: Instrument Profile name.
-        session_type: Type of session.
-        raw_data: JSON string of sweep results.
-    """
-    doc = frappe.new_doc("Impedance Snapshot")
-    doc.instrument = instrument
-    doc.session_type = session_type
-    doc.json_data = raw_data
-    peak = doc.append("peaks", {})
-    peak.frequency = 0
-    peak.impedance = 0
-    peak.q_factor = 0
-    doc.insert(ignore_permissions=True)
-    return {"name": doc.name}
+
+@frappe.whitelist(allow_guest=False, methods=["POST"])
+@frappe.only_for(["Technician"])
+def save_impedance_snapshot(instrument: str, session_type: str, raw_data: str) -> dict:
+    """Persist an Impedance Snapshot document."""
+    try:
+        peaks = _parse_json(raw_data)
+        doc = frappe.new_doc("Impedance Snapshot")
+        doc.instrument = instrument
+        doc.session_type = session_type
+        doc.json_data = raw_data
+        for row in peaks or [{}]:
+            doc.append(
+                "peaks",
+                {
+                    "frequency": row.get("frequency", 0),
+                    "impedance": row.get("impedance", 0),
+                    "q_factor": row.get("q_factor", 0),
+                },
+            )
+        doc.insert(ignore_permissions=True)
+        return {"name": doc.name}
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "save_impedance_snapshot failed")
+        frappe.throw("Unable to save impedance snapshot")
+
+
+@frappe.whitelist(allow_guest=False, methods=["POST"])
+@frappe.only_for(["Technician"])
+def save_intonation_session(instrument: str, session_type: str, raw_data: str) -> dict:
+    """Persist an Intonation Session document."""
+    try:
+        notes = _parse_json(raw_data)
+        doc = frappe.new_doc("Intonation Session")
+        doc.instrument = instrument
+        doc.session_type = session_type
+        doc.json_data = raw_data
+        for row in notes or [{}]:
+            doc.append(
+                "notes",
+                {
+                    "note_name": row.get("note_name"),
+                    "cents_offset": row.get("cents_offset"),
+                    "time_logged": row.get("time_logged"),
+                },
+            )
+        doc.insert(ignore_permissions=True)
+        return {"name": doc.name}
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "save_intonation_session failed")
+        frappe.throw("Unable to save intonation session")
+
+
+@frappe.whitelist(allow_guest=False, methods=["POST"])
+@frappe.only_for(["Technician"])
+def save_leak_test(instrument: str, session_type: str, raw_data: str) -> dict:
+    """Persist a Leak Test document."""
+    try:
+        readings = _parse_json(raw_data)
+        doc = frappe.new_doc("Leak Test")
+        doc.instrument = instrument
+        doc.session_type = session_type
+        doc.json_data = raw_data
+        for row in readings or [{}]:
+            doc.append(
+                "readings",
+                {
+                    "tone_hole": row.get("tone_hole"),
+                    "leak_score": row.get("leak_score"),
+                    "time_logged": row.get("time_logged"),
+                },
+            )
+        doc.insert(ignore_permissions=True)
+        return {"name": doc.name}
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "save_leak_test failed")
+        frappe.throw("Unable to save leak test")
+
+
+@frappe.whitelist(allow_guest=False, methods=["POST"])
+@frappe.only_for(["Technician"])
+def save_reed_match_result(instrument: str, session_type: str, raw_data: str) -> dict:
+    """Persist a Reed Match Result document."""
+    try:
+        doc = frappe.new_doc("Reed Match Result")
+        doc.instrument = instrument
+        doc.session_type = session_type
+        doc.json_data = raw_data
+        doc.insert(ignore_permissions=True)
+        return {"name": doc.name}
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "save_reed_match_result failed")
+        frappe.throw("Unable to save reed match result")
+
+
+@frappe.whitelist(allow_guest=False, methods=["POST"])
+@frappe.only_for(["Technician"])
+def save_tone_fitness(instrument: str, session_type: str, raw_data: str) -> dict:
+    """Persist a Tone Fitness document."""
+    try:
+        entries = _parse_json(raw_data)
+        doc = frappe.new_doc("Tone Fitness")
+        doc.instrument = instrument
+        doc.session_type = session_type
+        doc.json_data = raw_data
+        for row in entries or [{}]:
+            doc.append(
+                "entries",
+                {
+                    "reading_time": row.get("reading_time"),
+                    "centroid": row.get("centroid"),
+                    "spread": row.get("spread"),
+                },
+            )
+        doc.insert(ignore_permissions=True)
+        return {"name": doc.name}
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "save_tone_fitness failed")
+        frappe.throw("Unable to save tone fitness")
+

--- a/repair_portal/lab/doctype/impedance_peak/impedance_peak.py
+++ b/repair_portal/lab/doctype/impedance_peak/impedance_peak.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/impedance_peak/impedance_peak.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Child table for impedance peak data.
+
 """Child table for impedance peak data."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class ImpedancePeak(Document):
     pass
+

--- a/repair_portal/lab/doctype/impedance_snapshot/impedance_snapshot.py
+++ b/repair_portal/lab/doctype/impedance_snapshot/impedance_snapshot.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/impedance_snapshot/impedance_snapshot.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Parent DocType to store impedance sweep snapshots.
+
 """Parent DocType to store impedance sweep snapshots."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class ImpedanceSnapshot(Document):
     pass
+

--- a/repair_portal/lab/doctype/intonation_note/intonation_note.py
+++ b/repair_portal/lab/doctype/intonation_note/intonation_note.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/intonation_note/intonation_note.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Child table for individual intonation readings.
+
 """Child table for individual intonation readings."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class IntonationNote(Document):
     pass
+

--- a/repair_portal/lab/doctype/intonation_session/intonation_session.py
+++ b/repair_portal/lab/doctype/intonation_session/intonation_session.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/intonation_session/intonation_session.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Parent DocType for smart intonation sessions.
+
 """Parent DocType for smart intonation sessions."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class IntonationSession(Document):
     pass
+

--- a/repair_portal/lab/doctype/leak_reading/leak_reading.py
+++ b/repair_portal/lab/doctype/leak_reading/leak_reading.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/leak_reading/leak_reading.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Child table for leak test readings.
+
 """Child table for leak test readings."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class LeakReading(Document):
     pass
+

--- a/repair_portal/lab/doctype/leak_test/leak_test.py
+++ b/repair_portal/lab/doctype/leak_test/leak_test.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/leak_test/leak_test.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Parent DocType for tone-hole leak tests.
+
 """Parent DocType for tone-hole leak tests."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class LeakTest(Document):
     pass
+

--- a/repair_portal/lab/doctype/reed_match_result/reed_match_result.py
+++ b/repair_portal/lab/doctype/reed_match_result/reed_match_result.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/reed_match_result/reed_match_result.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Parent DocType storing reed match results.
+
 """Parent DocType storing reed match results."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class ReedMatchResult(Document):
     pass
+

--- a/repair_portal/lab/doctype/tone_fitness/tone_fitness.py
+++ b/repair_portal/lab/doctype/tone_fitness/tone_fitness.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/tone_fitness/tone_fitness.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Parent DocType for brightness vs warmth measurements.
+
 """Parent DocType for brightness vs warmth measurements."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class ToneFitness(Document):
     pass
+

--- a/repair_portal/lab/doctype/tone_fitness_entry/tone_fitness_entry.py
+++ b/repair_portal/lab/doctype/tone_fitness_entry/tone_fitness_entry.py
@@ -1,3 +1,8 @@
+# File: repair_portal/lab/doctype/tone_fitness_entry/tone_fitness_entry.py
+# Updated: 2025-06-17
+# Version: 1.0
+# Purpose: Child table for tone fitness trend entries.
+
 """Child table for tone fitness trend entries."""
 
 from frappe.model.document import Document
@@ -5,3 +10,4 @@ from frappe.model.document import Document
 
 class ToneFitnessEntry(Document):
     pass
+

--- a/repair_portal/lab/page/lab_dashboard/lab_dashboard.js
+++ b/repair_portal/lab/page/lab_dashboard/lab_dashboard.js
@@ -14,23 +14,31 @@ frappe.pages["lab_dashboard"].on_page_load = function (wrapper) {
   );
   root.append('<div id="plot" class="mt-4"></div>');
 
-  document.getElementById("start-btn").addEventListener("click", async () => {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    const context = new (window.AudioContext || window.webkitAudioContext)();
-    const source = context.createMediaStreamSource(stream);
-    const analyser = context.createAnalyser();
-    source.connect(analyser);
-    const data = new Float32Array(analyser.fftSize);
-    analyser.getFloatFrequencyData(data);
-    frappe
-      .call("repair_portal.lab.api.save_impedance_snapshot", {
-        instrument: "",
-        session_type: "Standalone",
-        raw_data: JSON.stringify(Array.from(data)),
-      })
-      .then((r) => {
-        frappe.msgprint("Saved: " + r.message.name);
-      });
-    Plotly.newPlot("plot", [{ y: Array.from(data) }], { margin: { t: 0 } });
+  document.getElementById('start-btn').addEventListener('click', async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const context = new (window.AudioContext || window.webkitAudioContext)();
+      const source = context.createMediaStreamSource(stream);
+      const analyser = context.createAnalyser();
+      source.connect(analyser);
+      const data = new Float32Array(analyser.fftSize);
+      analyser.getFloatFrequencyData(data);
+
+      Plotly.newPlot('plot', [{ y: Array.from(data) }], { margin: { t: 0 } });
+
+      await frappe
+        .call('repair_portal.lab.api.save_impedance_snapshot', {
+          instrument: frappe.utils.get_url_arg('instrument') || '',
+          session_type: 'Standalone',
+          raw_data: JSON.stringify(Array.from(data)),
+        })
+        .then((r) => {
+          frappe.show_alert(__('Saved') + ': ' + r.message.name);
+        });
+    } catch (e) {
+      console.error(e);
+      frappe.msgprint(__('Microphone access failed.'));
+    }
   });
 };
+

--- a/repair_portal/test/test_lab_api.py
+++ b/repair_portal/test/test_lab_api.py
@@ -3,13 +3,57 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestLabAPI(FrappeTestCase):
-    def test_save_impedance_snapshot(self):
+    def setUp(self):
         frappe.set_user("Administrator")
+        self.instrument = frappe.get_doc(
+            {
+                "doctype": "Instrument Profile",
+                "instrument_category": "Clarinet",
+                "serial_number": "TEST-LAB",
+                "brand": "TestBrand",
+                "route": "test-lab-inst",
+            }
+        ).insert()
+
+    def test_save_impedance_snapshot(self):
         result = frappe.get_attr("repair_portal.lab.api.save_impedance_snapshot")(
-            instrument="INST-TEST",
+            instrument=self.instrument.name,
             session_type="Standalone",
             raw_data="[]",
         )
         assert frappe.db.exists("Impedance Snapshot", result["name"])
         child_count = frappe.db.count("Impedance Peak", {"parent": result["name"]})
         self.assertEqual(child_count, 1)
+
+    def test_save_intonation_session(self):
+        result = frappe.get_attr("repair_portal.lab.api.save_intonation_session")(
+            instrument=self.instrument.name,
+            session_type="Standalone",
+            raw_data="[]",
+        )
+        assert frappe.db.exists("Intonation Session", result["name"])
+
+    def test_save_leak_test(self):
+        result = frappe.get_attr("repair_portal.lab.api.save_leak_test")(
+            instrument=self.instrument.name,
+            session_type="Standalone",
+            raw_data="[]",
+        )
+        assert frappe.db.exists("Leak Test", result["name"])
+
+    def test_save_reed_match_result(self):
+        result = frappe.get_attr("repair_portal.lab.api.save_reed_match_result")(
+            instrument=self.instrument.name,
+            session_type="Standalone",
+            raw_data="{}",
+        )
+        assert frappe.db.exists("Reed Match Result", result["name"])
+
+    def test_save_tone_fitness(self):
+        result = frappe.get_attr("repair_portal.lab.api.save_tone_fitness")(
+            instrument=self.instrument.name,
+            session_type="Standalone",
+            raw_data="[]",
+        )
+        assert frappe.db.exists("Tone Fitness", result["name"])
+


### PR DESCRIPTION
## Summary
- fix Instrument Profile client script to link to lab dashboard
- implement lab API endpoints with validation and error logging
- enhance lab dashboard JS with error handling
- document lab DocTypes
- include audio libraries in hooks
- extend lab API tests

## Testing
- `pytest -q repair_portal/test/test_lab_api.py` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6854790e744483289ef325eff676ca1a