### PR TITLE
Add client portal dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
   - Tools: Tuner, Bore Scanner, Adhesive timer, Pad kit builder.
   - Bench Ops: Screw Map, Kanban, Video training.
 
+### 2025-07-10
+- Added dedicated Client Portal dashboard at `/me`.
+- Player and Instrument profile routes now use `/players/<name>` and `/instruments/<serial>`.
+- Updated portal menu to match new navigation scheme.
+
 ## Enabling Pulse Update Feature
 1. Run `bench migrate` to apply new DocTypes.
 2. Use `/repair_pulse?name=REQ-0001` to view live updates.

--- a/repair_portal/hooks.py
+++ b/repair_portal/hooks.py
@@ -18,8 +18,9 @@ website_generators = [
 ]
 
 portal_menu_items = [
-    {"title": "My Instruments", "route": "/my_instruments", "reference_doctype": "Instrument Profile"},
-    {"title": "My Repairs", "route": "/my_repairs", "reference_doctype": "Repair Request"},
-    {"title": "My Players", "route": "/my_players", "reference_doctype": "Player Profile"},
-    {"title": "Technician Dashboard", "route": "/technician_dashboard", "role": "Technician"},
+    {"title": "Dashboard", "route": "/me", "reference_doctype": "Client Profile"},
+    {"title": "Players", "route": "/my_players", "reference_doctype": "Player Profile"},
+    {"title": "Instruments", "route": "/my_instruments", "reference_doctype": "Instrument Profile"},
+    {"title": "Create Player", "route": "/app/player-profile/new"},
+    {"title": "Settings / Sign Out", "route": "/me?edit=1"},
 ]

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
@@ -1,6 +1,6 @@
-# File: repair_portal/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
-# Updated: 2025-06-17
-# Version: 1.3
+# File: repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
+# Updated: 2025-07-10
+# Version: 1.4
 # Purpose: Auto-generates route for web profile and links to ERPNext
 
 import frappe
@@ -11,13 +11,15 @@ class InstrumentProfile(WebsiteGenerator):
     website = frappe._dict(
         condition_field="published",
         page_title_field="serial_number",
-        route="route"
+        route="route",
     )
 
     def validate(self):
-        # Auto-set route from serial number
-        if not self.route and self.serial_number:
-            self.route = frappe.scrub(self.serial_number)
+        """Ensure route is prefixed with instruments/"""
+        if self.serial_number and not self.route:
+            self.route = f"instruments/{frappe.scrub(self.serial_number)}"
+        elif self.route and not self.route.startswith("instruments/"):
+            self.route = f"instruments/{self.route.lstrip('/')}"
 
     def get_context(self, context):
         context.parents = [{"title": "Instrument Catalog", "route": "/my_instruments"}]

--- a/repair_portal/instrument_profile/doctype/player_profile/player_profile.py
+++ b/repair_portal/instrument_profile/doctype/player_profile/player_profile.py
@@ -1,3 +1,8 @@
+# File: repair_portal/instrument_profile/doctype/player_profile/player_profile.py
+# Updated: 2025-07-10
+# Version: 1.2
+# Purpose: WebsiteGenerator for player profiles with prefixed routes.
+
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
@@ -6,9 +11,16 @@ class PlayerProfile(WebsiteGenerator):
     website = frappe._dict(
         condition_field="published",
         page_title_field="player_name",
-        route="route"
+        route="route",
     )
+
+    def validate(self):
+        """Set default route under /players."""
+        if self.player_name and not self.route:
+            self.route = f"players/{frappe.scrub(self.player_name)}"
+        elif self.route and not self.route.startswith("players/"):
+            self.route = f"players/{self.route.lstrip('/')}"
 
     def get_context(self, context):
         context.title = self.player_name
-        context.parents = [{"title": "My Players", "route": "/dashboard"}]
+        context.parents = [{"title": "My Players", "route": "/my_players"}]

--- a/repair_portal/templates/pages/me.html
+++ b/repair_portal/templates/pages/me.html
@@ -1,0 +1,29 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<h1>{{ profile.client_name }}</h1>
+<p>Email: {{ profile.email }}</p>
+<p>Phone: {{ profile.phone }}</p>
+
+<h2>Consent Log</h2>
+<ul>
+  {% for entry in consent_log %}
+  <li>{{ entry.consent_type }} – {{ entry.date_given }}</li>
+  {% endfor %}
+</ul>
+
+<h2>Instruments</h2>
+<ul>
+  {% for inst in instruments %}
+  <li><a href="/instruments/{{ inst.route }}">{{ inst.instrument_name }} ({{ inst.serial_number }})</a></li>
+  {% endfor %}
+</ul>
+
+<h2>Player Profiles</h2>
+<ul>
+  {% for p in players %}
+  <li><a href="/players/{{ p.route }}">{{ p.player_name }}</a></li>
+  {% endfor %}
+</ul>
+{% endblock %}
+

--- a/repair_portal/www/me.py
+++ b/repair_portal/www/me.py
@@ -1,0 +1,39 @@
+"""Client profile dashboard for the logged-in user."""
+
+# File: repair_portal/www/me.py
+# Updated: 2025-07-10
+# Version: 1.0
+# Purpose: Display client profile details with linked players and instruments.
+
+from __future__ import annotations
+
+import frappe
+
+login_required = True
+
+
+def get_context(context):
+    """Build context for /me route."""
+    user = frappe.session.user
+    client = frappe.get_doc("Client Profile", {"linked_user": user})
+
+    instruments = frappe.get_all(
+        "Instrument Profile",
+        filters={"client_profile": client.name},
+        fields=["name", "instrument_name", "serial_number", "route"],
+        order_by="creation desc",
+    )
+
+    players = frappe.get_all(
+        "Player Profile",
+        filters={"client_profile": client.name},
+        fields=["name", "player_name", "route"],
+        order_by="creation desc",
+    )
+
+    context.profile = client
+    context.consent_log = client.get("consent_log")
+    context.instruments = instruments
+    context.players = players
+    context.title = client.client_name
+    return context


### PR DESCRIPTION
## Summary
- add `/me` dashboard page for client profiles
- prefix website routes for player and instrument profiles
- update portal menu items
- document portal updates

## Testing
- `ruff check --fix repair_portal/www/me.py repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py repair_portal/instrument_profile/doctype/player_profile/player_profile.py repair_portal/hooks.py`
- `black repair_portal/www/me.py repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py repair_portal/instrument_profile/doctype/player_profile/player_profile.py repair_portal/hooks.py`
- `bench --site erp.artisanclarinets.com migrate` *(fails: command not found)*
- `bench run-tests --app repair_portal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685797bb22f48328b10a465647572391