### PR TITLE
Add instrument timeline feed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,32 +4,39 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04.5
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+    runs-on: ubuntu-22.04           # GitHub runner tag, no patch number
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+    permissions:
+      contents: read                # least-privilege for forks
+
+    steps:
+      # ───────────────────────────── Git checkout ────────────────────────────
+      - name: Checkout code
+        uses: actions/checkout@v4    # v4 = faster/safer submodule handling
+
+      # ───────────────────────────── Node / Biome (JS+TS) ────────────────────
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 18          # Frappe v15 front-end toolchain uses ≥ 18
+          cache: "npm"
 
       - name: Install Biome
         run: npm install -g @biomejs/biome
 
+      - name: Run Biome
+        run: biome check .          # exits non-zero on any style error
 
+      # ───────────────────────────── Python / Ruff (back-end) ────────────────
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"    # v15 is tested & bundled against 3.10
 
       - name: Install Ruff
         run: |
           python -m pip install --upgrade pip
           pip install ruff
-          
-          
 
       - name: Run Ruff
-        run: ruff .
-        
+        run: ruff check .           # explicit sub-command, clearer in logs

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@
   - Tools: Tuner, Bore Scanner, Adhesive timer, Pad kit builder.
   - Bench Ops: Screw Map, Kanban, Video training.
 
+### 2025-07-10
+- Added dedicated Client Portal dashboard at `/me`.
+- Player and Instrument profile routes now use `/players/<name>` and `/instruments/<serial>`.
+- Updated portal menu to match new navigation scheme.
+
+### 2025-07-11
+- Added public landing page at `/`.
+- Fixed dashboard links to use stored routes directly.
+
+### 2025-07-12
+- Introduced **Lifetime Instrument Timeline** with Instrument Event table.
+- Instrument comments feed into the timeline.
+- Next Upgrade button suggests services via `/repair-hub/upgrade`.
+
 ## Enabling Pulse Update Feature
 1. Run `bench migrate` to apply new DocTypes.
 2. Use `/repair_pulse?name=REQ-0001` to view live updates.

--- a/repair_portal/hooks.py
+++ b/repair_portal/hooks.py
@@ -18,8 +18,9 @@ website_generators = [
 ]
 
 portal_menu_items = [
-    {"title": "My Instruments", "route": "/my_instruments", "reference_doctype": "Instrument Profile"},
-    {"title": "My Repairs", "route": "/my_repairs", "reference_doctype": "Repair Request"},
-    {"title": "My Players", "route": "/my_players", "reference_doctype": "Player Profile"},
-    {"title": "Technician Dashboard", "route": "/technician_dashboard", "role": "Technician"},
+    {"title": "Dashboard", "route": "/me", "reference_doctype": "Client Profile"},
+    {"title": "Players", "route": "/my_players", "reference_doctype": "Player Profile"},
+    {"title": "Instruments", "route": "/my_instruments", "reference_doctype": "Instrument Profile"},
+    {"title": "Create Player", "route": "/app/player-profile/new"},
+    {"title": "Settings / Sign Out", "route": "/me?edit=1"},
 ]

--- a/repair_portal/instrument_profile/README.md
+++ b/repair_portal/instrument_profile/README.md
@@ -4,8 +4,9 @@ Manages a clarinet’s full lifecycle: history, valuation, upgrades, and legal o
 
 ## Features Implemented
 - ✅ Lifetime Timeline
-  - Timeline of service events
-  - Linked to `Repair`, `QA`, and `Inspection` logs
+  - Scrollable feed of **Instrument Events** and player comments
+  - Aggregates Repair Orders, photos, and manual notes
+- ✅ "Next Upgrade" suggestions with route to `/repair-hub/upgrade`
 - ✅ Market-Value Tracker
   - Scheduled script pulls average valuations from eBay/Reverb
   - Field stored on Instrument
@@ -22,4 +23,4 @@ Manages a clarinet’s full lifecycle: history, valuation, upgrades, and legal o
 - Scheduler jobs in `instrument_profile.scheduler`
 
 ---
-Last updated: 2025-07-03
+Last updated: 2025-07-12

--- a/repair_portal/instrument_profile/doctype/instrument_comment/__init__.py
+++ b/repair_portal/instrument_profile/doctype/instrument_comment/__init__.py
@@ -1,0 +1,4 @@
+# File: instrument_profile/doctype/instrument_comment/__init__.py
+# Updated: 2025-07-12
+# Version: 1.0
+# Purpose: Package marker for Instrument Comment DocType.

--- a/repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.json
+++ b/repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.json
@@ -1,0 +1,19 @@
+{
+  "doctype": "DocType",
+  "name": "Instrument Comment",
+  "module": "Instrument Profile",
+  "custom": 0,
+  "fields": [
+    {"fieldname": "instrument_profile", "label": "Instrument", "fieldtype": "Link", "options": "Instrument Profile", "reqd": 1},
+    {"fieldname": "player_profile", "label": "Player", "fieldtype": "Link", "options": "Player Profile"},
+    {"fieldname": "comment", "label": "Comment", "fieldtype": "Small Text", "reqd": 1},
+    {"fieldname": "comment_by", "label": "Comment By", "fieldtype": "Link", "options": "User"}
+  ],
+  "permissions": [
+    {"role": "Customer", "read": 1, "create": 1, "if_owner": 1},
+    {"role": "Technician", "read": 1, "write": 1},
+    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1}
+  ],
+  "editable_grid": 1,
+  "istable": 0
+}

--- a/repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.py
+++ b/repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.py
@@ -1,0 +1,10 @@
+# File: repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.py
+# Updated: 2025-07-12
+# Version: 1.0
+# Purpose: Standalone DocType for player comments on an instrument.
+
+from frappe.model.document import Document
+
+
+class InstrumentComment(Document):
+    pass

--- a/repair_portal/instrument_profile/doctype/instrument_event/__init__.py
+++ b/repair_portal/instrument_profile/doctype/instrument_event/__init__.py
@@ -1,0 +1,4 @@
+# File: instrument_profile/doctype/instrument_event/__init__.py
+# Updated: 2025-07-12
+# Version: 1.0
+# Purpose: Package marker for Instrument Event child table.

--- a/repair_portal/instrument_profile/doctype/instrument_event/instrument_event.json
+++ b/repair_portal/instrument_profile/doctype/instrument_event/instrument_event.json
@@ -1,0 +1,23 @@
+{
+  "doctype": "DocType",
+  "name": "Instrument Event",
+  "module": "Instrument Profile",
+  "custom": 0,
+  "fields": [
+    {"fieldname": "parent", "fieldtype": "Link", "options": "Instrument Profile", "hidden": 1},
+    {"fieldname": "parentfield", "fieldtype": "Data", "hidden": 1},
+    {"fieldname": "parenttype", "fieldtype": "Data", "hidden": 1},
+    {"fieldname": "idx", "fieldtype": "Int", "hidden": 1},
+    {"fieldname": "date", "label": "Date", "fieldtype": "Date", "reqd": 1},
+    {"fieldname": "event_type", "label": "Event Type", "fieldtype": "Select", "options": "Service\nRepair\nPhoto\nComment"},
+    {"fieldname": "description", "label": "Description", "fieldtype": "Small Text"},
+    {"fieldname": "photo", "label": "Photo", "fieldtype": "Attach Image"},
+    {"fieldname": "reference_link", "label": "Reference Link", "fieldtype": "Data"}
+  ],
+  "permissions": [
+    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1},
+    {"role": "Technician", "read": 1, "write": 1, "create": 1}
+  ],
+  "editable_grid": 1,
+  "istable": 1
+}

--- a/repair_portal/instrument_profile/doctype/instrument_event/instrument_event.py
+++ b/repair_portal/instrument_profile/doctype/instrument_event/instrument_event.py
@@ -1,0 +1,12 @@
+# File: repair_portal/instrument_profile/doctype/instrument_event/instrument_event.py
+# Updated: 2025-07-12
+# Version: 1.0
+# Purpose: Child table to store instrument timeline events.
+
+from frappe.model.document import Document
+
+
+class InstrumentEvent(Document):
+    """Simple child table for timeline entries."""
+
+    pass

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.js
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.js
@@ -22,5 +22,54 @@ frappe.ui.form.on('Instrument Profile', {
     frm.add_custom_button('View Lab Data', () => {
       frappe.set_route('lab-dashboard', { instrument: frm.doc.name });
     });
+
+    if (!frm.is_new()) {
+      render_timeline(frm);
+      frm.add_custom_button('Next Upgrade', () => {
+        const upgrade = suggest_next_upgrade(frm.doc);
+        frappe.set_route('/repair-hub/upgrade', {
+          instrument: frm.doc.name,
+          sku: upgrade.sku,
+        });
+      });
+    }
   },
 });
+
+function render_timeline(frm) {
+  frappe
+    .call('repair_portal.instrument_profile.utils.get_instrument_timeline', {
+      name: frm.doc.name,
+    })
+    .then((r) => {
+      const events = r.message || [];
+      const html = ['<ul class="timeline list-unstyled">'];
+      events.forEach((ev) => {
+        html.push(
+          `<li class="timeline-item mb-3">` +
+            `<span class="badge bg-primary me-2">${frappe.format_date(ev.date)}</span>` +
+            (ev.photo ? `<img src="${ev.photo}" class="img-thumbnail me-2" style="height:40px;">` : '') +
+            `${ev.description}` +
+            (ev.reference_link ? ` <a href="${ev.reference_link}" class="ms-2">View</a>` : '') +
+            `</li>`
+        );
+      });
+      html.push('</ul>');
+      frm.dashboard.add_section(html.join(''), 'Lifetime Instrument Timeline');
+      frm.dashboard.show();
+    });
+}
+
+function suggest_next_upgrade(doc) {
+  const today = frappe.datetime.now_date();
+  const creation = doc.creation ? frappe.datetime.str_to_obj(doc.creation) : frappe.datetime.str_to_obj(today);
+  const last_service = doc.last_service_date ? frappe.datetime.str_to_obj(doc.last_service_date) : creation;
+  const age_years = frappe.datetime.get_year_diff(today, creation);
+  const last_years = frappe.datetime.get_year_diff(today, last_service);
+
+  let suggestion = { sku: 'BARREL', desc: 'Barrel upgrade' };
+  if (age_years >= 5 || last_years >= 5) {
+    suggestion = { sku: 'PADSET', desc: 'Full pad set' };
+  }
+  return suggestion;
+}

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
@@ -80,7 +80,8 @@
       "label": "Wellness Score",
       "fieldtype": "Int",
       "default": 0
-    }
+    },
+    {"fieldname": "instrument_events", "label": "Instrument Events", "fieldtype": "Table", "options": "Instrument Event"},
   ],
   "permissions": [
     {

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
@@ -1,6 +1,6 @@
-# File: repair_portal/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
-# Updated: 2025-06-17
-# Version: 1.3
+# File: repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.py
+# Updated: 2025-07-10
+# Version: 1.4
 # Purpose: Auto-generates route for web profile and links to ERPNext
 
 import frappe
@@ -11,13 +11,15 @@ class InstrumentProfile(WebsiteGenerator):
     website = frappe._dict(
         condition_field="published",
         page_title_field="serial_number",
-        route="route"
+        route="route",
     )
 
     def validate(self):
-        # Auto-set route from serial number
-        if not self.route and self.serial_number:
-            self.route = frappe.scrub(self.serial_number)
+        """Ensure route is prefixed with instruments/"""
+        if self.serial_number and not self.route:
+            self.route = f"instruments/{frappe.scrub(self.serial_number)}"
+        elif self.route and not self.route.startswith("instruments/"):
+            self.route = f"instruments/{self.route.lstrip('/')}"
 
     def get_context(self, context):
         context.parents = [{"title": "Instrument Catalog", "route": "/my_instruments"}]

--- a/repair_portal/instrument_profile/doctype/player_profile/player_profile.py
+++ b/repair_portal/instrument_profile/doctype/player_profile/player_profile.py
@@ -1,3 +1,8 @@
+# File: repair_portal/instrument_profile/doctype/player_profile/player_profile.py
+# Updated: 2025-07-10
+# Version: 1.2
+# Purpose: WebsiteGenerator for player profiles with prefixed routes.
+
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
@@ -6,9 +11,16 @@ class PlayerProfile(WebsiteGenerator):
     website = frappe._dict(
         condition_field="published",
         page_title_field="player_name",
-        route="route"
+        route="route",
     )
+
+    def validate(self):
+        """Set default route under /players."""
+        if self.player_name and not self.route:
+            self.route = f"players/{frappe.scrub(self.player_name)}"
+        elif self.route and not self.route.startswith("players/"):
+            self.route = f"players/{self.route.lstrip('/')}"
 
     def get_context(self, context):
         context.title = self.player_name
-        context.parents = [{"title": "My Players", "route": "/dashboard"}]
+        context.parents = [{"title": "My Players", "route": "/my_players"}]

--- a/repair_portal/instrument_profile/utils.py
+++ b/repair_portal/instrument_profile/utils.py
@@ -1,0 +1,95 @@
+# File: repair_portal/instrument_profile/utils.py
+# Updated: 2025-07-12
+# Version: 1.0
+# Purpose: Helper utilities for Instrument Profile module.
+
+from __future__ import annotations
+
+import frappe
+
+
+def get_instrument_timeline(name: str) -> list[dict]:
+    """Return ordered list of events for the given instrument."""
+    doc = frappe.get_doc("Instrument Profile", name)
+    events = []
+
+    # manual events table
+    for ev in doc.instrument_events:
+        events.append(
+            {
+                "date": ev.date,
+                "event_type": ev.event_type,
+                "description": ev.description,
+                "photo": ev.photo,
+                "reference_link": ev.reference_link,
+            }
+        )
+
+    # repair orders
+    repair_orders = frappe.get_all(
+        "Repair Order",
+        filters={"instrument_profile": name},
+        fields=["name", "status", "modified"],
+    )
+    for ro in repair_orders:
+        events.append(
+            {
+                "date": ro.modified,
+                "event_type": "Repair",
+                "description": f"Repair Order {ro.name} - {ro.status}",
+                "reference_link": f"/app/repair-order/{ro.name}",
+            }
+        )
+
+    # repair task logs
+    task_logs = frappe.db.get_all(
+        "Repair Task Log",
+        fields=["timestamp", "log_entry", "parent"],
+        order_by="timestamp asc",
+    )
+    for log in task_logs:
+        parent_repair = frappe.db.get_value("Repair Task", log.parent, "parent")
+        instrument = frappe.db.get_value("Repair Order", parent_repair, "instrument_profile")
+        if instrument == name:
+            events.append(
+                {
+                    "date": log.timestamp,
+                    "event_type": "Repair Task",
+                    "description": log.log_entry,
+                    "reference_link": f"/app/repair-task/{log.parent}",
+                }
+            )
+
+    # photos
+    photos = frappe.db.get_all("Image Log Entry", fields=["image", "comment", "parent", "creation"])
+    for photo in photos:
+        task_parent = frappe.db.get_value("Repair Task", photo.parent, "parent")
+        inst = frappe.db.get_value("Repair Order", task_parent, "instrument_profile")
+        if inst == name:
+            events.append(
+                {
+                    "date": photo.creation,
+                    "event_type": "Photo",
+                    "description": photo.comment,
+                    "photo": photo.image,
+                    "reference_link": f"/app/repair-task/{photo.parent}",
+                }
+            )
+
+    # player comments
+    comments = frappe.get_all(
+        "Instrument Comment",
+        filters={"instrument_profile": name},
+        fields=["comment", "creation"],
+    )
+    for cm in comments:
+        events.append(
+            {
+                "date": cm.creation,
+                "event_type": "Comment",
+                "description": cm.comment,
+                "reference_link": None,
+            }
+        )
+
+    return sorted(events, key=lambda x: x["date"])

--- a/repair_portal/templates/pages/index.html
+++ b/repair_portal/templates/pages/index.html
@@ -1,0 +1,11 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<h1>Welcome to the Clarinet Repair Portal</h1>
+<p>Manage your instruments, players and repairs in one place.</p>
+{% if frappe.session.user != 'Guest' %}
+  <a class="btn btn-primary" href="/me">Go to Dashboard</a>
+{% else %}
+  <a class="btn btn-primary" href="/login">Sign In</a>
+{% endif %}
+{% endblock %}

--- a/repair_portal/templates/pages/me.html
+++ b/repair_portal/templates/pages/me.html
@@ -1,0 +1,29 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<h1>{{ profile.client_name }}</h1>
+<p>Email: {{ profile.email }}</p>
+<p>Phone: {{ profile.phone }}</p>
+
+<h2>Consent Log</h2>
+<ul>
+  {% for entry in consent_log %}
+  <li>{{ entry.consent_type }} – {{ entry.date_given }}</li>
+  {% endfor %}
+</ul>
+
+<h2>Instruments</h2>
+<ul>
+  {% for inst in instruments %}
+  <li><a href="/{{ inst.route }}">{{ inst.instrument_name }} ({{ inst.serial_number }})</a></li>
+  {% endfor %}
+</ul>
+
+<h2>Player Profiles</h2>
+<ul>
+  {% for p in players %}
+  <li><a href="/{{ p.route }}">{{ p.player_name }}</a></li>
+  {% endfor %}
+</ul>
+{% endblock %}
+

--- a/repair_portal/test/test_instrument_timeline.py
+++ b/repair_portal/test/test_instrument_timeline.py
@@ -1,0 +1,38 @@
+import unittest
+
+import frappe
+
+from repair_portal.instrument_profile.utils import get_instrument_timeline
+
+
+class TestInstrumentTimeline(unittest.TestCase):
+    def test_timeline_generation(self):
+        frappe.set_user("Administrator")
+        inst = frappe.get_doc(
+            {
+                "doctype": "Instrument Profile",
+                "instrument_category": "Clarinet",
+                "serial_number": "TLN-001",
+                "route": "tln-001",
+            }
+        ).insert()
+        inst.append(
+            "instrument_events",
+            {
+                "date": "2025-07-10",
+                "event_type": "Service",
+                "description": "Initial setup",
+            },
+        )
+        inst.save()
+
+        frappe.get_doc(
+            {
+                "doctype": "Instrument Comment",
+                "instrument_profile": inst.name,
+                "comment": "Great sound!",
+            }
+        ).insert()
+
+        events = get_instrument_timeline(inst.name)
+        assert len(events) >= 2

--- a/repair_portal/www/README.md
+++ b/repair_portal/www/README.md
@@ -59,6 +59,7 @@ This directory contains all **Python page controllers** for custom web routes in
 
 ## Directory Map (as of 2025-06-21)
 
+- `index.py`                →  Portal landing page
 - `my_instruments.py`         →  Main instrument list view *(🆕 template added)*
 - `my_repairs.py`             →  Client/user's repair history
 - `my_players.py`             →  Player directory (for each client)
@@ -86,5 +87,6 @@ This directory contains all **Python page controllers** for custom web routes in
 ### Update Log
 - **2025-06-21**: Created missing templates `my_instruments.html` and `instrument_wellness.html`.
 - **2024-06-19**: Legacy pages consolidated. `repair_pulse.html` moved to `templates/pages/`.
+- **2025-07-11**: Added `index.py` landing page and fixed dashboard link routes.
 
 For any questions or contributions, see the main project README or contact Dylan Thompson (MRW Artisan Instruments).

--- a/repair_portal/www/index.py
+++ b/repair_portal/www/index.py
@@ -1,0 +1,13 @@
+"""Landing page for the repair portal."""
+
+# File: repair_portal/www/index.py
+# Updated: 2025-07-11
+# Version: 1.0
+# Purpose: Provide the public portal landing page.
+
+
+def get_context(context):
+    """Return base context for the landing page."""
+    context.no_cache = True
+    context.title = "Clarinet Repair Portal"
+    return context

--- a/repair_portal/www/me.py
+++ b/repair_portal/www/me.py
@@ -1,0 +1,39 @@
+"""Client profile dashboard for the logged-in user."""
+
+# File: repair_portal/www/me.py
+# Updated: 2025-07-10
+# Version: 1.0
+# Purpose: Display client profile details with linked players and instruments.
+
+from __future__ import annotations
+
+import frappe
+
+login_required = True
+
+
+def get_context(context):
+    """Build context for /me route."""
+    user = frappe.session.user
+    client = frappe.get_doc("Client Profile", {"linked_user": user})
+
+    instruments = frappe.get_all(
+        "Instrument Profile",
+        filters={"client_profile": client.name},
+        fields=["name", "instrument_name", "serial_number", "route"],
+        order_by="creation desc",
+    )
+
+    players = frappe.get_all(
+        "Player Profile",
+        filters={"client_profile": client.name},
+        fields=["name", "player_name", "route"],
+        order_by="creation desc",
+    )
+
+    context.profile = client
+    context.consent_log = client.get("consent_log")
+    context.instruments = instruments
+    context.players = players
+    context.title = client.client_name
+    return context


### PR DESCRIPTION
## Summary
- introduce Lifetime Instrument Timeline table and comments
- render timeline and Next Upgrade suggestions in Instrument Profile
- expose `get_instrument_timeline` util
- document new portal features

## Testing
- `ruff check --fix repair_portal/instrument_profile/doctype/instrument_event/instrument_event.py repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.py repair_portal/instrument_profile/utils.py repair_portal/test/test_instrument_timeline.py`
- `black repair_portal/instrument_profile/doctype/instrument_event/instrument_event.py repair_portal/instrument_profile/doctype/instrument_comment/instrument_comment.py repair_portal/instrument_profile/utils.py repair_portal/test/test_instrument_timeline.py`
- `bench --site erp.artisanclarinets.com migrate` *(fails: You should not run this command as root)*
- `bench --site erp.artisanclarinets.com clear-cache` *(fails: You should not run this command as root)*
- `bench export-fixtures --app repair_portal` *(fails: You should not run this command as root)*
- `bench run-tests --app repair_portal` *(fails: You should not run this command as root)*

------
https://chatgpt.com/codex/tasks/task_e_685797bb22f48328b10a465647572391