### PR TITLE
Add Technician role permissions to Instrument Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@
 ### Next Steps
 - Add unit tests
 - Add CI hooks via GitHub Actions
+- Added Technician access entry for Instrument Profile DocType
 
 *Last updated: 2025-06-26*

--- a/repair_portal/instrument_profile/README.md
+++ b/repair_portal/instrument_profile/README.md
@@ -4,3 +4,6 @@
 
 ### 2025-06-16
 - Created Instrument Category DocType and Python controller at `doctype/instrument_category/`.
+
+### 2025-06-26
+- Added Technician role permissions for Instrument Profile DocType.

--- a/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
+++ b/repair_portal/instrument_profile/doctype/instrument_profile/instrument_profile.json
@@ -22,6 +22,7 @@
     {"fieldname": "published", "label": "Published", "fieldtype": "Check", "default": 1}
   ],
   "permissions": [
-    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1}
+    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1},
+    {"role": "Technician", "read": 1, "write": 1, "create": 1}
   ]
 }


### PR DESCRIPTION
## Summary
- allow Technicians to read, write and create Instrument Profiles
- document permission update in module README
- mention permission update in root README

## Testing
- `bench --site erp.artisanclarinets.com migrate`
- `bench --site erp.artisanclarinets.com clear-cache`
- `bench export-fixtures --app repair_portal`
- `bench run-tests --app repair_portal`


------
https://chatgpt.com/codex/tasks/task_e_685da3734ba4832886214d19fd107eeb