### PR TITLE
Add customer dashboard portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 - Added new DocType: Clarinet Inspection (parent, links Inspection Finding as child)
 - Scaffolded clarinet_inspection.json and clarinet_inspection.py in instrument_setup/doctype
 - Prepping to update Clarinet Initial Setup linkage
+
+### [2025-07-18] Client Portal Dashboard
+- Added /me/dashboard portal exposing Client, Player and Instrument Profiles.

--- a/repair_portal/api/dashboard.py
+++ b/repair_portal/api/dashboard.py
@@ -1,0 +1,46 @@
+import frappe
+from frappe import _
+
+
+@frappe.whitelist()
+def get_profiles():
+    """Return client, player, and instrument profiles for the logged-in user."""
+    user = frappe.session.user
+    if user == "Guest":
+        frappe.throw(_("Login required"), frappe.PermissionError)
+
+    client = frappe.db.get_value("Client Profile", {"linked_user": user}, "*", as_dict=True)
+    if not client:
+        return {"client": None, "players": [], "instruments": []}
+
+    players = frappe.get_all(
+        "Player Profile",
+        filters={"client_profile": client.name},
+        fields=["name", "player_name"],
+    )
+    player_names = [p.name for p in players]
+
+    instruments = []
+    if player_names:
+        instruments = frappe.get_all(
+            "Instrument Profile",
+            filters={"player_profile": ["in", player_names]},
+            fields=["name", "serial_no"],
+        )
+
+    return {"client": client, "players": players, "instruments": instruments}
+
+
+@frappe.whitelist()
+def save_profile(docname, data):
+    """Update a document owned by the user after permission check."""
+    if isinstance(data, str):
+        data = frappe.parse_json(data)
+
+    doc = frappe.get_doc(docname)
+    if not frappe.has_permission(doc.doctype, ptype="write", doc=docname):
+        frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+    doc.update(data)
+    doc.save()
+    return {"name": doc.name}

--- a/repair_portal/build.json
+++ b/repair_portal/build.json
@@ -1,0 +1,8 @@
+{
+  "dashboard.bundle.js": [
+    "repair_portal/public/js/dashboard.js"
+  ],
+  "dashboard.bundle.css": [
+    "repair_portal/public/css/dashboard.css"
+  ]
+}

--- a/repair_portal/fixtures/portal_perms.json
+++ b/repair_portal/fixtures/portal_perms.json
@@ -1,0 +1,37 @@
+[
+  {
+    "doctype": "Custom DocPerm",
+    "role": "Customer",
+    "parent": "Client Profile",
+    "permlevel": 0,
+    "read": 1,
+    "write": 1,
+    "if_owner": 1
+  },
+  {
+    "doctype": "Custom DocPerm",
+    "role": "Customer",
+    "parent": "Player Profile",
+    "permlevel": 0,
+    "read": 1,
+    "write": 1,
+    "if_owner": 1
+  },
+  {
+    "doctype": "Custom DocPerm",
+    "role": "Customer",
+    "parent": "Instrument Profile",
+    "permlevel": 0,
+    "read": 1,
+    "write": 1,
+    "if_owner": 1
+  },
+  {
+    "doctype": "Custom DocPerm",
+    "role": "Technician",
+    "parent": "Instrument Profile",
+    "permlevel": 0,
+    "read": 1,
+    "write": 1
+  }
+]

--- a/repair_portal/hooks.py
+++ b/repair_portal/hooks.py
@@ -14,8 +14,9 @@ app_version = "1.2.2"
 
 
 app_include_css = [
-	 "/public/css/clarinetfest.css",
- 	 "/public/css/product_catalog.css",
+         "/public/css/clarinetfest.css",
+         "/public/css/product_catalog.css",
+        "/assets/repair_portal/dashboard.bundle.css",
 ]
 
 
@@ -23,8 +24,9 @@ app_include_js = [
     "/public/js/client_portal/client_portal.bundle.js",
     "/public/js/technician_dashboard/technician_dashboard.bundle.js",
     "/public/js/technician_dashboard/index.dum.js",
-	"/public/js/recording_analyzer.bundle.js",
-	"/public/js/intonation_recorder.bundle.js",
+    "/public/js/recording_analyzer.bundle.js",
+    "/public/js/intonation_recorder.bundle.js",
+    "/assets/repair_portal/dashboard.bundle.js",
 ]
 
 fixtures = [
@@ -64,5 +66,14 @@ doc_events = {
         "on_cancel": "repair_portal.repair_order.doctype.repair_order.repair_order.RepairOrder.on_cancel"
     }
 }
+
+portal_menu_items = [
+    {
+        "title": "My Dashboard",
+        "route": "/me/dashboard",
+        "reference_doctype": "Client Profile",
+        "role": "Customer",
+    }
+]
 
 

--- a/repair_portal/public/css/dashboard.css
+++ b/repair_portal/public/css/dashboard.css
@@ -1,0 +1,7 @@
+#dashboard-tabs button {
+cursor: pointer;
+}
+
+#dashboard-content .card {
+border: 1px solid #ddd;
+}

--- a/repair_portal/public/js/dashboard.js
+++ b/repair_portal/public/js/dashboard.js
@@ -1,0 +1,96 @@
+frappe.ready(() => {
+load_profiles();
+});
+
+function load_profiles() {
+frappe.call('repair_portal.api.dashboard.get_profiles').then(r => {
+const data = r.message || {};
+render_client(data.client);
+render_players(data.players || []);
+render_instruments(data.instruments || []);
+});
+}
+
+function render_client(client) {
+const wrap = document.getElementById('client-pane');
+wrap.innerHTML = '';
+if (!client) {
+wrap.innerHTML = '<p>No Client Profile found.</p>';
+return;
+}
+const html = `
+<div class="card">
+<div class="card-body">
+<h5 class="card-title">${frappe.utils.escape_html(client.client_name || '')}</h5>
+<p>Email: ${frappe.utils.escape_html(client.email || '')}</p>
+<p>Phone: ${frappe.utils.escape_html(client.phone || '')}</p>
+<button class="btn btn-primary btn-sm" id="edit-client">Edit</button>
+</div>
+</div>`;
+wrap.innerHTML = html;
+wrap.querySelector('#edit-client').addEventListener('click', () => {
+open_edit_dialog('Client Profile', client.name, [
+{fieldname: 'client_name', label: 'Client Name', fieldtype: 'Data', reqd: 1, default: client.client_name},
+{fieldname: 'email', label: 'Email', fieldtype: 'Data', default: client.email},
+{fieldname: 'phone', label: 'Phone', fieldtype: 'Data', default: client.phone}
+]);
+});
+}
+
+function render_players(players) {
+const wrap = document.getElementById('player-pane');
+wrap.innerHTML = '';
+if (!players.length) {
+wrap.innerHTML = '<p>No Player Profiles.</p>';
+return;
+}
+players.forEach(p => {
+const div = document.createElement('div');
+div.className = 'card mb-2';
+div.innerHTML = `<div class="card-body">
+<h5 class="card-title">${frappe.utils.escape_html(p.player_name)}</h5>
+<button class="btn btn-primary btn-sm" data-name="${p.name}">Edit</button>
+</div>`;
+div.querySelector('button').addEventListener('click', (e) => {
+open_edit_dialog('Player Profile', p.name, [
+{fieldname: 'player_name', label: 'Player Name', fieldtype: 'Data', reqd: 1, default: p.player_name}
+]);
+});
+wrap.appendChild(div);
+});
+}
+
+function render_instruments(instruments) {
+const wrap = document.getElementById('instrument-pane');
+wrap.innerHTML = '';
+if (!instruments.length) {
+wrap.innerHTML = '<p>No Instrument Profiles.</p>';
+return;
+}
+instruments.forEach(i => {
+const div = document.createElement('div');
+div.className = 'card mb-2';
+div.innerHTML = `<div class="card-body">
+<h5 class="card-title">${frappe.utils.escape_html(i.serial_no || i.name)}</h5>
+<button class="btn btn-primary btn-sm" data-name="${i.name}">Edit</button>
+</div>`;
+div.querySelector('button').addEventListener('click', () => {
+open_edit_dialog('Instrument Profile', i.name, [
+{fieldname: 'serial_no', label: 'Serial No', fieldtype: 'Data', reqd: 1, default: i.serial_no}
+]);
+});
+wrap.appendChild(div);
+});
+}
+
+function open_edit_dialog(doctype, docname, fields) {
+const dialog = new frappe.ui.Dialog({title: `Edit ${doctype}`, fields});
+dialog.set_primary_action('Save', () => {
+const values = dialog.get_values();
+frappe.call('repair_portal.api.dashboard.save_profile', {docname, data: values}).then(() => {
+dialog.hide();
+load_profiles();
+});
+});
+dialog.show();
+}

--- a/repair_portal/tests/test_portal_permissions.py
+++ b/repair_portal/tests/test_portal_permissions.py
@@ -1,0 +1,76 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPortalPermissions(FrappeTestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+
+        for email in ("alice@example.com", "bob@example.com", "tech@example.com"):
+            if not frappe.db.exists("User", email):
+                user = frappe.get_doc({
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                })
+                user.insert(ignore_permissions=True)
+
+        frappe.get_doc({
+            "doctype": "Client Profile",
+            "client_name": "Alice",
+            "linked_user": "alice@example.com",
+        }).insert(ignore_permissions=True)
+
+        frappe.get_doc({
+            "doctype": "Client Profile",
+            "client_name": "Bob",
+            "linked_user": "bob@example.com",
+        }).insert(ignore_permissions=True)
+
+        player_a = frappe.get_doc({
+            "doctype": "Player Profile",
+            "player_name": "A",
+            "client_profile": frappe.db.get_value(
+                "Client Profile", {"linked_user": "alice@example.com"}
+            ),
+        }).insert(ignore_permissions=True)
+
+        player_b = frappe.get_doc({
+            "doctype": "Player Profile",
+            "player_name": "B",
+            "client_profile": frappe.db.get_value(
+                "Client Profile", {"linked_user": "bob@example.com"}
+            ),
+        }).insert(ignore_permissions=True)
+
+        frappe.get_doc({
+            "doctype": "Instrument Profile",
+            "serial_no": "A1",
+            "player_profile": player_a.name,
+        }).insert(ignore_permissions=True)
+
+        frappe.get_doc({
+            "doctype": "Instrument Profile",
+            "serial_no": "B1",
+            "player_profile": player_b.name,
+        }).insert(ignore_permissions=True)
+
+        tech = frappe.get_doc("User", "tech@example.com")
+        tech.add_roles("Technician")
+        frappe.db.commit()
+
+    def test_customer_cannot_fetch_others(self):
+        frappe.set_user("alice@example.com")
+        other_client = frappe.db.get_value(
+            "Client Profile", {"linked_user": "bob@example.com"}
+        )
+        with self.assertRaises(frappe.PermissionError):  # noqa: PT027
+            frappe.get_doc("Client Profile", other_client)
+
+    def test_technician_can_access(self):
+        frappe.set_user("tech@example.com")
+        instrument = frappe.db.get_value("Instrument Profile", {"serial_no": "B1"})
+        try:
+            frappe.get_doc("Instrument Profile", instrument)
+        except frappe.PermissionError:
+            self.fail("Technician should access instrument")

--- a/repair_portal/www/me/dashboard/index.html
+++ b/repair_portal/www/me/dashboard/index.html
@@ -1,0 +1,23 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<section class="container my-4">
+    <h1>My Dashboard</h1>
+    <ul class="nav nav-tabs" id="dashboard-tabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="client-tab" data-bs-toggle="tab" data-bs-target="#client-pane" type="button" role="tab">Client</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="player-tab" data-bs-toggle="tab" data-bs-target="#player-pane" type="button" role="tab">Player</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="instrument-tab" data-bs-toggle="tab" data-bs-target="#instrument-pane" type="button" role="tab">Instrument</button>
+        </li>
+    </ul>
+    <div class="tab-content pt-3" id="dashboard-content">
+        <div class="tab-pane fade show active" id="client-pane" role="tabpanel"></div>
+        <div class="tab-pane fade" id="player-pane" role="tabpanel"></div>
+        <div class="tab-pane fade" id="instrument-pane" role="tabpanel"></div>
+    </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create dashboard portal page for client, player and instrument profiles
- build dashboard JS/CSS assets and include in hooks
- expose secure API endpoints for fetching and saving profiles
- declare portal permissions fixtures
- add failing portal permission tests placeholder
- document new dashboard in README

## Testing
- `ruff check repair_portal/api/dashboard.py repair_portal/tests/test_portal_permissions.py`
- `pytest repair_portal/tests/test_portal_permissions.py -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6879931e01d08328a5ea60e8bdfe6bce