### PR TITLE
Align repair workflow doctypes and dashboards with schema

### DIFF
--- a/repair_portal/api/intake_dashboard.py
+++ b/repair_portal/api/intake_dashboard.py
@@ -8,12 +8,17 @@ import frappe
 
 @frappe.whitelist(allow_guest=False)
 def get_intake_counts():
+    statuses = [
+        'Pending',
+        'Received',
+        'Inspection',
+        'Repair',
+        'Awaiting Customer Approval',
+        'Complete',
+    ]
     return {
-        'New': frappe.db.count('Clarinet Intake', {'workflow_state': 'New'}),
-        'Received': frappe.db.count('Clarinet Intake', {'workflow_state': 'Received'}),
-        'Inspection': frappe.db.count('Clarinet Intake', {'workflow_state': 'Inspection'}),
-        'QC': frappe.db.count('Clarinet Intake', {'workflow_state': 'QC'}),
-        'Hold': frappe.db.count('Clarinet Intake', {'workflow_state': 'Hold'}),
+        status: frappe.db.count('Clarinet Intake', {'intake_status': status})
+        for status in statuses
     }
 
 
@@ -21,7 +26,7 @@ def get_intake_counts():
 def get_recent_intakes():
     return frappe.get_all(
         'Clarinet Intake',
-        fields=['name', 'workflow_state', 'client', 'player', 'modified'],
+        fields=['name', 'intake_status', 'customer', 'instrument', 'modified'],
         order_by='modified desc',
         limit=10,
     )

--- a/repair_portal/hooks.py
+++ b/repair_portal/hooks.py
@@ -47,16 +47,18 @@ after_migrate = [
 
 
 doc_events = {
-    'Repair Order': {
-        'on_submit': 'repair_portal.repair_order.doctype.repair_order.repair_order.RepairOrder.on_submit',
-        'on_cancel': 'repair_portal.repair_order.doctype.repair_order.repair_order.RepairOrder.on_cancel',
+    "Repair Order": {
+        "on_submit": "repair_portal.repair.doctype.repair_order.repair_order.RepairOrder.on_submit",
+        "on_cancel": "repair_portal.repair.doctype.repair_order.repair_order.RepairOrder.on_cancel",
     },
-    'Clarinet Intake': {
+    "Clarinet Intake": {
         # after_insert will call our new function
-        'after_insert': (
-            'repair_portal.intake.doctype.clarinet_intake'
-            + '.clarinet_intake_timeline.add_timeline_entries'
-        )
+        "after_insert": (
+            "repair_portal.intake.doctype.clarinet_intake"
+            + ".clarinet_intake_timeline.add_timeline_entries"
+        ),
+        "validate": "repair_portal.repair.utils.on_child_validate",
+        "on_update": "repair_portal.repair.utils.on_child_validate",
     },
     'Instrument': {
         'after_insert': 'repair_portal.instrument_profile.services.profile_sync.on_linked_doc_change',
@@ -82,11 +84,6 @@ doc_events = {
     },
     # End Optional handlers
 
-    # Begin Repair Order Doc Events
-    "Clarinet Intake": {
-        "validate": "repair_portal.repair.utils.on_child_validate",
-        "on_update": "repair_portal.repair.utils.on_child_validate",
-    },
     "Instrument Inspection": {
         "validate": "repair_portal.repair.utils.on_child_validate",
         "on_update": "repair_portal.repair.utils.on_child_validate",
@@ -115,9 +112,9 @@ doc_events = {
         "validate": "repair_portal.repair.utils.on_child_validate",
         "on_update": "repair_portal.repair.utils.on_child_validate",
     },
-     "Stock Entry": {
-    "after_submit": "repair_portal.repair.hooks_stock_entry.after_submit_stock_entry"
-  }
+    "Stock Entry": {
+        "after_submit": "repair_portal.repair.hooks_stock_entry.after_submit_stock_entry",
+    },
 }
 
 

--- a/repair_portal/inspection/doctype/instrument_inspection/instrument_inspection.json
+++ b/repair_portal/inspection/doctype/instrument_inspection/instrument_inspection.json
@@ -13,11 +13,12 @@
     "serial_no",
     "clarinet_intake",
     "intake_record_id",
+    "repair_order",
     "col_overview_right",
     "inspected_by",
     "customer",
+    "instrument_profile",
     "preliminary_estimate",
-
     "sec_new_inventory",
     "manufacturer",
     "model",
@@ -33,7 +34,6 @@
     "acclimatization_playing_schedule",
     "acclimatization_swabbing",
     "instrument_delivered",
-
     "sec_condition",
     "overall_condition",
     "condition",
@@ -44,7 +44,6 @@
     "bore_condition",
     "bore_notes",
     "tone_hole_inspection",
-
     "sec_specs",
     "body_material",
     "key_plating",
@@ -58,22 +57,18 @@
     "thumb_rest",
     "spring_type",
     "pad_type_current",
-
     "sec_status",
     "current_status",
     "current_location",
     "qc_certificate",
     "digital_signature",
-
     "sec_media",
     "profile_image",
     "marketing_photos",
     "service_photos",
     "audio_video_demos",
-
     "sec_accessories",
     "accessory_log",
-
     "sec_audit",
     "amended_from"
   ],
@@ -121,7 +116,10 @@
       "label": "Intake Record ID",
       "options": "Clarinet Intake"
     },
-    { "fieldname": "col_overview_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_overview_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "inspected_by",
       "fieldtype": "Link",
@@ -142,7 +140,6 @@
       "fieldtype": "Currency",
       "label": "Preliminary Estimate"
     },
-
     {
       "fieldname": "sec_new_inventory",
       "fieldtype": "Section Break",
@@ -200,7 +197,10 @@
       "fieldtype": "Attach Image",
       "label": "Hygrometer Reading Photo"
     },
-    { "fieldname": "col_new_inventory_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_new_inventory_right",
+      "fieldtype": "Column Break"
+    },
     {
       "default": "0",
       "depends_on": "eval:doc.inspection_type === 'New Inventory'",
@@ -236,7 +236,6 @@
       "fieldtype": "Check",
       "label": "Instrument Delivered to Customer"
     },
-
     {
       "fieldname": "sec_condition",
       "fieldtype": "Section Break",
@@ -266,7 +265,10 @@
       "fieldtype": "Text",
       "label": "General Notes"
     },
-    { "fieldname": "col_condition_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_condition_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "tenon_fit_assessment",
       "fieldtype": "Table",
@@ -292,7 +294,6 @@
       "label": "Tone Hole Visual Inspection",
       "options": "Tone Hole Inspection Record"
     },
-
     {
       "fieldname": "sec_specs",
       "fieldtype": "Section Break",
@@ -325,7 +326,10 @@
       "fieldtype": "Data",
       "label": "Pitch Standard"
     },
-    { "fieldname": "col_specs_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_specs_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "bore_style",
       "fieldtype": "Data",
@@ -356,7 +360,6 @@
       "fieldtype": "Data",
       "label": "Pad Type (Current)"
     },
-
     {
       "fieldname": "sec_status",
       "fieldtype": "Section Break",
@@ -384,7 +387,6 @@
       "fieldtype": "Signature",
       "label": "Technician Signature"
     },
-
     {
       "fieldname": "sec_media",
       "fieldtype": "Section Break",
@@ -414,7 +416,6 @@
       "label": "Audio/Video Demos",
       "options": "Instrument Media"
     },
-
     {
       "fieldname": "sec_accessories",
       "fieldtype": "Section Break",
@@ -427,7 +428,6 @@
       "label": "Current Accessories Log",
       "options": "Instrument Accessory"
     },
-
     {
       "fieldname": "sec_audit",
       "fieldtype": "Section Break",
@@ -443,6 +443,19 @@
       "print_hide": 1,
       "read_only": 1,
       "search_index": 1
+    },
+    {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
+    },
+    {
+      "fieldname": "instrument_profile",
+      "label": "Instrument Profile",
+      "fieldtype": "Link",
+      "options": "Instrument Profile"
     }
   ],
   "is_submittable": 1,
@@ -463,7 +476,13 @@
       "submit": 1,
       "write": 1
     },
-    { "create": 1, "read": 1, "role": "Technician", "submit": 1, "write": 1 },
+    {
+      "create": 1,
+      "read": 1,
+      "role": "Technician",
+      "submit": 1,
+      "write": 1
+    },
     {
       "create": 1,
       "delete": 1,
@@ -477,10 +496,25 @@
   "sort_field": "modified",
   "sort_order": "DESC",
   "states": [
-    { "color": "Light Blue", "title": "Pending" },
-    { "color": "Green", "title": "In Progress" },
-    { "color": "Purple", "title": "Referred to Setup" },
-    { "color": "Orange", "title": "Referred to Repair" },
-    { "color": "Yellow", "title": "Referred to Maintenance" }
+    {
+      "color": "Light Blue",
+      "title": "Pending"
+    },
+    {
+      "color": "Green",
+      "title": "In Progress"
+    },
+    {
+      "color": "Purple",
+      "title": "Referred to Setup"
+    },
+    {
+      "color": "Orange",
+      "title": "Referred to Repair"
+    },
+    {
+      "color": "Yellow",
+      "title": "Referred to Maintenance"
+    }
   ]
 }

--- a/repair_portal/intake/doctype/clarinet_intake/clarinet_intake.json
+++ b/repair_portal/intake/doctype/clarinet_intake/clarinet_intake.json
@@ -18,11 +18,9 @@
   "modified": "2025-09-19 17:00:00.000000",
   "sort_field": "modified",
   "sort_order": "DESC",
-
   "title_field": "intake_record_id",
   "image_field": "initial_intake_photos",
   "search_fields": "intake_record_id, serial_no, customer, manufacturer, model, item_code",
-
   "field_order": [
     "sec_overview",
     "intake_record_id",
@@ -31,8 +29,9 @@
     "col_overview_right",
     "employee",
     "instrument",
+    "instrument_profile",
     "intake_status",
-
+    "repair_order",
     "sec_instrument_identity",
     "instrument_category",
     "manufacturer",
@@ -47,7 +46,6 @@
     "bore_type",
     "tone_hole_style",
     "thumb_rest_type",
-
     "sec_inventory_pricing",
     "item_code",
     "item_name",
@@ -55,7 +53,6 @@
     "col_inventory_right",
     "acquisition_cost",
     "store_asking_price",
-
     "sec_customer_service",
     "customer",
     "customer_full_name",
@@ -72,7 +69,6 @@
     "customer_approval",
     "promised_completion_date",
     "consent_form",
-
     "instrument_condition_section",
     "wood_body_condition",
     "col_cond_mid",
@@ -81,17 +77,13 @@
     "pad_condition",
     "spring_condition",
     "cork_condition",
-
     "sec_photos",
     "initial_intake_photos",
-
     "sec_accessories",
     "accessory_id",
-
     "sec_audit",
     "amended_from"
   ],
-
   "fields": [
     {
       "fieldname": "sec_overview",
@@ -125,7 +117,10 @@
       "reqd": 1,
       "in_list_view": 1
     },
-    { "fieldname": "col_overview_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_overview_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "employee",
       "fieldtype": "Link",
@@ -152,7 +147,6 @@
       "in_list_view": 1,
       "in_standard_filter": 1
     },
-
     {
       "fieldname": "sec_instrument_identity",
       "fieldtype": "Section Break",
@@ -196,7 +190,7 @@
       "fieldname": "clarinet_type",
       "fieldtype": "Select",
       "label": "Type of Clarinet",
-      "options": "B♭ Clarinet\nA Clarinet\nE♭ Clarinet\nBass Clarinet\nAlto Clarinet\nContrabass Clarinet\nOther",
+      "options": "B\u266d Clarinet\nA Clarinet\nE\u266d Clarinet\nBass Clarinet\nAlto Clarinet\nContrabass Clarinet\nOther",
       "reqd": 1
     },
     {
@@ -204,7 +198,10 @@
       "fieldtype": "Int",
       "label": "Year of Manufacture"
     },
-    { "fieldname": "col_inst_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_inst_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "body_material",
       "fieldtype": "Data",
@@ -238,7 +235,6 @@
       "fieldtype": "Data",
       "label": "Thumb Rest Type"
     },
-
     {
       "fieldname": "sec_inventory_pricing",
       "fieldtype": "Section Break",
@@ -267,7 +263,10 @@
       "label": "Acquisition Source",
       "depends_on": "eval:doc.intake_type == 'New Inventory'"
     },
-    { "fieldname": "col_inventory_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_inventory_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "acquisition_cost",
       "fieldtype": "Currency",
@@ -280,7 +279,6 @@
       "label": "Store Asking Price",
       "depends_on": "eval:doc.intake_type == 'New Inventory'"
     },
-
     {
       "fieldname": "sec_customer_service",
       "fieldtype": "Section Break",
@@ -324,7 +322,10 @@
       "options": "Professional\nStudent\nUniversity\nCollector",
       "depends_on": "eval:doc.intake_type != 'New Inventory'"
     },
-    { "fieldname": "col_customer_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_customer_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "customers_stated_issue",
       "fieldtype": "Small Text",
@@ -379,7 +380,6 @@
       "options": "Consent Form",
       "depends_on": "eval:doc.intake_type != 'Repair'"
     },
-
     {
       "fieldname": "instrument_condition_section",
       "fieldtype": "Section Break",
@@ -392,14 +392,20 @@
       "label": "Wood/Body Condition",
       "options": "Excellent\nAcceptable\nNeeds Attention"
     },
-    { "fieldname": "col_cond_mid", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_cond_mid",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "keywork_condition",
       "fieldtype": "Select",
       "label": "Keywork Condition",
       "options": "Excellent\nAcceptable\nNeeds Attention"
     },
-    { "fieldname": "col_cond_right", "fieldtype": "Column Break" },
+    {
+      "fieldname": "col_cond_right",
+      "fieldtype": "Column Break"
+    },
     {
       "fieldname": "pad_condition",
       "fieldtype": "Select",
@@ -418,7 +424,6 @@
       "label": "Cork Condition",
       "options": "Excellent\nAcceptable\nNeeds Attention"
     },
-
     {
       "fieldname": "sec_photos",
       "fieldtype": "Section Break",
@@ -430,7 +435,6 @@
       "fieldtype": "Attach",
       "label": "Initial Intake Photos"
     },
-
     {
       "fieldname": "sec_accessories",
       "fieldtype": "Section Break",
@@ -443,7 +447,6 @@
       "label": "Accessories & Included Parts",
       "options": "Intake Accessory Item"
     },
-
     {
       "fieldname": "sec_audit",
       "fieldtype": "Section Break",
@@ -459,9 +462,22 @@
       "print_hide": 1,
       "read_only": 1,
       "search_index": 1
+    },
+    {
+      "fieldname": "instrument_profile",
+      "label": "Instrument Profile",
+      "fieldtype": "Link",
+      "options": "Instrument Profile",
+      "read_only": 0
+    },
+    {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
     }
   ],
-
   "permissions": [
     {
       "role": "System Manager",
@@ -478,19 +494,53 @@
       "create": 1,
       "submit": 1
     },
-    { "role": "Technician", "read": 1, "write": 1, "create": 1 }
+    {
+      "role": "Technician",
+      "read": 1,
+      "write": 1,
+      "create": 1
+    }
   ],
-
   "states": [
-    { "title": "Pending", "color": "Light Blue" },
-    { "title": "Received", "color": "Blue" },
-    { "title": "Inspection", "color": "Green" },
-    { "title": "Setup", "color": "Green" },
-    { "title": "Repair", "color": "Green" },
-    { "title": "Awaiting Custom Approval", "color": "Orange" },
-    { "title": "Awaiting Payment", "color": "Yellow" },
-    { "title": "In Transit", "color": "Light Blue" },
-    { "title": "Repair Complete", "color": "Orange" },
-    { "title": "Returned to Customer", "color": "Purple" }
+    {
+      "title": "Pending",
+      "color": "Light Blue"
+    },
+    {
+      "title": "Received",
+      "color": "Blue"
+    },
+    {
+      "title": "Inspection",
+      "color": "Green"
+    },
+    {
+      "title": "Setup",
+      "color": "Green"
+    },
+    {
+      "title": "Repair",
+      "color": "Green"
+    },
+    {
+      "title": "Awaiting Custom Approval",
+      "color": "Orange"
+    },
+    {
+      "title": "Awaiting Payment",
+      "color": "Yellow"
+    },
+    {
+      "title": "In Transit",
+      "color": "Light Blue"
+    },
+    {
+      "title": "Repair Complete",
+      "color": "Orange"
+    },
+    {
+      "title": "Returned to Customer",
+      "color": "Purple"
+    }
   ]
 }

--- a/repair_portal/lab/doctype/measurement_session/measurement_session.json
+++ b/repair_portal/lab/doctype/measurement_session/measurement_session.json
@@ -10,6 +10,19 @@
   "title_field": "instrument",
   "fields": [
     {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
+    },
+    {
+      "fieldname": "customer",
+      "label": "Customer",
+      "fieldtype": "Link",
+      "options": "Customer"
+    },
+    {
       "fieldname": "instrument",
       "label": "Instrument",
       "fieldtype": "Link",

--- a/repair_portal/qa/doctype/final_qa_checklist/final_qa_checklist.json
+++ b/repair_portal/qa/doctype/final_qa_checklist/final_qa_checklist.json
@@ -8,6 +8,25 @@
   "sync_on_migrate": 1,
   "fields": [
     {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
+    },
+    {
+      "fieldname": "customer",
+      "label": "Customer",
+      "fieldtype": "Link",
+      "options": "Customer"
+    },
+    {
+      "fieldname": "instrument_profile",
+      "label": "Instrument Profile",
+      "fieldtype": "Link",
+      "options": "Instrument Profile"
+    },
+    {
       "fieldname": "qa_technician",
       "fieldtype": "Link",
       "label": "QA Technician",

--- a/repair_portal/repair/doctype/repair_order/repair_order.py
+++ b/repair_portal/repair/doctype/repair_order/repair_order.py
@@ -155,19 +155,22 @@ class RepairOrder(Document):
         def opt(fieldname: str) -> str | None:
             return self.get(fieldname) if self.meta.has_field(fieldname) else None
 
-        linkmap = {
+        link_candidates = {
             # Optional stage links only if such fields exist on schema
-            "Clarinet Intake": opt("clarinet_intake"),
-            "Instrument Inspection": opt("instrument_inspection"),
-            "Service Plan": opt("service_plan"),
-            "Repair Estimate": opt("repair_estimate"),
-            "Measurement Session": opt("measurement_session"),
+            "Clarinet Intake": ["clarinet_intake", "intake"],
+            "Instrument Inspection": ["instrument_inspection"],
+            "Service Plan": ["service_plan"],
+            "Repair Estimate": ["repair_estimate"],
+            "Measurement Session": ["measurement_session"],
             # Always attempt to include Instrument Profile (first-class)
-            "Instrument Profile": opt("instrument_profile"),
+            "Instrument Profile": ["instrument_profile"],
         }
-        for dt, name in linkmap.items():
-            if name:
-                self._ensure_related(dt, name, desc="Stage link")
+        for dt, candidates in link_candidates.items():
+            for fieldname in candidates:
+                name = opt(fieldname)
+                if name:
+                    self._ensure_related(dt, name, desc="Stage link")
+                    break
 
     def _ensure_related(self, doctype: str, name: str, desc: str = "") -> None:
         rows = (self.related_documents or []) if self.meta.has_field("related_documents") else []

--- a/repair_portal/repair/hooks_stock_entry.py
+++ b/repair_portal/repair/hooks_stock_entry.py
@@ -31,7 +31,8 @@ def after_submit_stock_entry(doc, method=None):
         return
 
     # Mirror into RO.actual_materials
-    from repair_portal.repair_portal.repair.doctype.repair_order.repair_order import (
-        _update_actuals_from_se,
+    from repair_portal.repair.doctype.repair_order.repair_order import (
+        refresh_actuals_from_stock_entry,
     )
-    _update_actuals_from_se(ro_name, doc.name)
+
+    refresh_actuals_from_stock_entry(ro_name, doc.name)

--- a/repair_portal/repair/utils.py
+++ b/repair_portal/repair/utils.py
@@ -67,12 +67,12 @@ from frappe.utils import now_datetime
 DOC_CONFIG = {
     "Clarinet Intake": {"customer": "customer", "instrument": "instrument_profile"},
     "Instrument Inspection": {"customer": "customer", "instrument": "instrument_profile"},
-    "Service Plan": {"customer": "customer", "instrument": "instrument_profile"},
+    "Service Plan": {"customer": "customer", "instrument": "instrument"},
     "Repair Estimate": {"customer": "customer", "instrument": "instrument_profile"},
     "Final QA Checklist": {"customer": "customer", "instrument": "instrument_profile"},
-    "Measurement Session": {"customer": "customer", "instrument": "instrument_profile"},
+    "Measurement Session": {"customer": "customer", "instrument": "instrument"},
     "Diagnostic Metrics": {"customer": "customer", "instrument": "instrument_profile"},
-    "Repair Task": {"customer": "customer", "instrument": "instrument_profile"},
+    "Repair Task": {},
 }
 
 def on_child_validate(doc, method=None):

--- a/repair_portal/repair_logging/doctype/diagnostic_metrics/diagnostic_metrics.json
+++ b/repair_portal/repair_logging/doctype/diagnostic_metrics/diagnostic_metrics.json
@@ -22,6 +22,25 @@
   ],
   "fields": [
     {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
+    },
+    {
+      "fieldname": "customer",
+      "label": "Customer",
+      "fieldtype": "Link",
+      "options": "Customer"
+    },
+    {
+      "fieldname": "instrument_profile",
+      "label": "Instrument Profile",
+      "fieldtype": "Link",
+      "options": "Instrument Profile"
+    },
+    {
       "fieldname": "metric",
       "label": "Metric",
       "fieldtype": "Select",

--- a/repair_portal/service_planning/doctype/repair_estimate/repair_estimate.json
+++ b/repair_portal/service_planning/doctype/repair_estimate/repair_estimate.json
@@ -7,17 +7,76 @@
   "istable": 0,
   "editable_grid": 1,
   "fields": [
-    {"fieldname": "customer_name", "label": "Customer Name", "fieldtype": "Data", "reqd": 1},
-    {"fieldname": "instrument_id", "label": "Instrument ID", "fieldtype": "Data"},
-    {"fieldname": "inspection_reference", "label": "Inspection Reference", "fieldtype": "Link", "options": "Inspection Report"},
-    {"fieldname": "estimated_completion", "label": "Estimated Completion", "fieldtype": "Date"},
-    {"fieldname": "line_items", "label": "Line Items", "fieldtype": "Table", "options": "Estimate Line Item"},
-    {"fieldname": "total_cost", "label": "Total Cost", "fieldtype": "Currency", "read_only": 1, "depends_on": "eval:doc.line_items"}
+    {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
+    },
+    {
+      "fieldname": "customer",
+      "label": "Customer",
+      "fieldtype": "Link",
+      "reqd": 1,
+      "options": "Customer"
+    },
+    {
+      "fieldname": "instrument_profile",
+      "label": "Instrument Profile",
+      "fieldtype": "Link",
+      "options": "Instrument Profile"
+    },
+    {
+      "fieldname": "inspection_reference",
+      "label": "Inspection Reference",
+      "fieldtype": "Link",
+      "options": "Inspection Report"
+    },
+    {
+      "fieldname": "estimated_completion",
+      "label": "Estimated Completion",
+      "fieldtype": "Date"
+    },
+    {
+      "fieldname": "line_items",
+      "label": "Line Items",
+      "fieldtype": "Table",
+      "options": "Estimate Line Item"
+    },
+    {
+      "fieldname": "total_cost",
+      "label": "Total Cost",
+      "fieldtype": "Currency",
+      "read_only": 1,
+      "depends_on": "eval:doc.line_items"
+    }
   ],
   "permissions": [
-    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1, "submit": 1, "cancel": 1},
-    {"role": "Repair Manager", "read": 1, "write": 1, "create": 1},
-    {"role": "Technician", "read": 1, "create": 1},
-    {"role": "Customer", "read": 1, "if_owner": 1}
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1,
+      "submit": 1,
+      "cancel": 1
+    },
+    {
+      "role": "Repair Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1
+    },
+    {
+      "role": "Technician",
+      "read": 1,
+      "create": 1
+    },
+    {
+      "role": "Customer",
+      "read": 1,
+      "if_owner": 1
+    }
   ]
 }

--- a/repair_portal/service_planning/doctype/service_plan/service_plan.json
+++ b/repair_portal/service_planning/doctype/service_plan/service_plan.json
@@ -1,69 +1,86 @@
 {
-	"doctype": "DocType",
-	"name": "Service Plan",
-	"module": "Service Planning",
-	"engine": "InnoDB",
-	"custom": 0,
-	"fields": [
-		{ "fieldname": "plan_date", "label": "Plan Date", "fieldtype": "Date" },
-		{
-			"fieldname": "instrument",
-			"label": "Instrument",
-			"fieldtype": "Link",
-			"options": "Instrument Profile"
-		},
-		{
-			"fieldname": "estimated_cost",
-			"label": "Estimated Cost",
-			"fieldtype": "Currency"
-		},
-		{
-			"fieldname": "labor_hours",
-			"label": "Labor Hours",
-			"fieldtype": "Float"
-		},
-		{
-			"fieldname": "notes",
-			"label": "Notes",
-			"fieldtype": "Small Text",
-			"description": "Planning notes or special instructions for this service plan."
-		},
-		{
-			"fieldname": "tasks",
-			"label": "Planned Tasks",
-			"fieldtype": "Table",
-			"options": "Repair Task Log"
-		},
-		{
-			"fieldname": "plan_status",
-			"label": "Plan Status",
-			"fieldtype": "Select",
-			"options": "Draft\nScheduled\nIn Progress\nCompleted\nArchived",
-			"default": "Draft",
-			"read_only": 1,
-			"in_list_view": 1,
-			"description": "Current workflow state of this service plan. Managed by workflow automation."
-		}
-	],
-	"permissions": [
-		{
-			"role": "System Manager",
-			"read": 1,
-			"write": 1,
-			"create": 1,
-			"delete": 1
-		},
-		{
-			"role": "Repair Manager",
-			"read": 1,
-			"write": 1,
-			"create": 1,
-			"delete": 1
-		},
-		{
-			"role": "Technician",
-			"read": 1,
-			"create": 1
-		}
-	]
+  "doctype": "DocType",
+  "name": "Service Plan",
+  "module": "Service Planning",
+  "engine": "InnoDB",
+  "custom": 0,
+  "fields": [
+    {
+      "fieldname": "customer",
+      "label": "Customer",
+      "fieldtype": "Link",
+      "options": "Customer"
+    },
+    {
+      "fieldname": "repair_order",
+      "label": "Repair Order",
+      "fieldtype": "Link",
+      "options": "Repair Order",
+      "reqd": 1
+    },
+    {
+      "fieldname": "plan_date",
+      "label": "Plan Date",
+      "fieldtype": "Date"
+    },
+    {
+      "fieldname": "instrument",
+      "label": "Instrument",
+      "fieldtype": "Link",
+      "options": "Instrument Profile"
+    },
+    {
+      "fieldname": "estimated_cost",
+      "label": "Estimated Cost",
+      "fieldtype": "Currency"
+    },
+    {
+      "fieldname": "labor_hours",
+      "label": "Labor Hours",
+      "fieldtype": "Float"
+    },
+    {
+      "fieldname": "notes",
+      "label": "Notes",
+      "fieldtype": "Small Text",
+      "description": "Planning notes or special instructions for this service plan."
+    },
+    {
+      "fieldname": "tasks",
+      "label": "Planned Tasks",
+      "fieldtype": "Table",
+      "options": "Repair Task Log"
+    },
+    {
+      "fieldname": "plan_status",
+      "label": "Plan Status",
+      "fieldtype": "Select",
+      "options": "Draft\nScheduled\nIn Progress\nCompleted\nArchived",
+      "default": "Draft",
+      "read_only": 1,
+      "in_list_view": 1,
+      "description": "Current workflow state of this service plan. Managed by workflow automation."
+    }
+  ],
+  "permissions": [
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
+    },
+    {
+      "role": "Repair Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
+    },
+    {
+      "role": "Technician",
+      "read": 1,
+      "create": 1
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- fix Repair Order doc_events wiring and stock entry hook imports to match real module paths
- add Repair Order/customer/instrument links across workflow doctypes and update normalization/validation utilities
- update client portal and technician/intake dashboards to reference existing fields and expose instrument labels

## Testing
- python scripts/schema_guard.py

------
https://chatgpt.com/codex/tasks/task_b_68e20a71a1a8832c8d7e7ea4cc620ad2