### PR TITLE
Add security coverage and throttling safeguards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,23 @@ repos:
       - id: ruff-format
         name: "Run ruff formatter"
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        name: "mypy (repair_portal)"
+        entry: mypy --config-file mypy.ini
+        types: [python]
+        pass_filenames: false
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        name: "bandit (repair_portal)"
+        args: ["-r", "repair_portal", "-x", "repair_portal/tests"]
+        pass_filenames: false
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:

--- a/repair_portal/instrument_profile/cron/test_warranty_expiry_check.py
+++ b/repair_portal/instrument_profile/cron/test_warranty_expiry_check.py
@@ -1,0 +1,32 @@
+"""Unit tests covering warranty notification throttling helpers."""
+
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from repair_portal.instrument_profile.cron import warranty_expiry_check as warranty
+
+
+class TestWarrantyExpiryThrottle(FrappeTestCase):
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+    def test_within_daily_limit_enforces_cap(self):
+        recipient = "throttle@example.com"
+        category = "customer:expiring"
+        key = warranty._recipient_throttle_key(recipient, category)
+        frappe.cache().delete(key)
+
+        self.assertTrue(warranty._within_daily_limit(recipient, category, limit=2))
+        self.assertTrue(warranty._within_daily_limit(recipient, category, limit=2))
+        self.assertFalse(warranty._within_daily_limit(recipient, category, limit=2))
+
+    def test_throttle_is_case_insensitive(self):
+        category = "admin:early"
+        key = warranty._recipient_throttle_key("Admin@Example.com", category)
+        frappe.cache().delete(key)
+
+        self.assertTrue(warranty._within_daily_limit("Admin@Example.com", category, limit=1))
+        self.assertFalse(warranty._within_daily_limit("admin@example.com", category, limit=1))

--- a/repair_portal/instrument_profile/doctype/client_instrument_profile/client_instrument_profile.py
+++ b/repair_portal/instrument_profile/doctype/client_instrument_profile/client_instrument_profile.py
@@ -166,10 +166,14 @@ class ClientInstrumentProfile(Document):
             raise ValidationError(_("Insufficient permissions to create Client Instrument Profile"))
         
         # Additional role-based checks
-        user_roles = frappe.get_roles(frappe.session.user)
-        allowed_roles = ["System Manager", "Customer", "Portal User", "Repair Manager"]
-        
-        if not any(role in user_roles for role in allowed_roles):
+        allowed_roles = [
+            "System Manager",
+            "Customer",
+            "Portal User",
+            "Repair Manager",
+        ]
+
+        if not any(frappe.has_role(role=role) for role in allowed_roles):
             raise ValidationError(_("User role not authorized for Client Instrument Profile creation"))
 
     def _validate_and_sanitize_inputs(self):
@@ -297,10 +301,9 @@ class ClientInstrumentProfile(Document):
         
         # Only authorized users can change verification status
         if self.has_value_changed('verification_status'):
-            user_roles = frappe.get_roles(frappe.session.user)
             authorized_roles = ['Technician', 'Repair Manager', 'System Manager']
-            
-            if not any(role in user_roles for role in authorized_roles):
+
+            if not any(frappe.has_role(role=role) for role in authorized_roles):
                 raise ValidationError(_('Only technicians can change verification status'))
             
             # Log verification status changes

--- a/repair_portal/instrument_profile/doctype/instrument_serial_number/test_instrument_serial_number_security.py
+++ b/repair_portal/instrument_profile/doctype/instrument_serial_number/test_instrument_serial_number_security.py
@@ -1,0 +1,155 @@
+"""Security regression tests for Instrument Serial Number."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+if TYPE_CHECKING:
+    from frappe.model.document import Document
+
+
+class TestInstrumentSerialNumberSecurity(FrappeTestCase):
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+        if not frappe.db.exists("Brand", "Security ISN Brand"):
+            frappe.get_doc({
+                "doctype": "Brand",
+                "brand": "Security ISN Brand",
+            }).insert(ignore_permissions=True)
+
+        self.instrument = frappe.get_doc({
+            "doctype": "Instrument",
+            "serial_no": f"SEC-ISN-{frappe.generate_hash(length=5)}",
+            "brand": "Security ISN Brand",
+            "clarinet_type": "Bb Clarinet",
+            "current_status": "Active",
+        })
+        self.instrument.insert(ignore_permissions=True)
+
+        self.isn = frappe.get_doc({
+            "doctype": "Instrument Serial Number",
+            "serial": f"SECISN-{frappe.generate_hash(length=4)}",
+            "instrument": self.instrument.name,
+        })
+        self.isn.insert(ignore_permissions=True)
+
+        self.addCleanup(lambda: frappe.set_user("Administrator"))
+
+    def tearDown(self):
+        if getattr(self, "isn", None):
+            frappe.delete_doc("Instrument Serial Number", self.isn.name, force=True, ignore_permissions=True)
+        if getattr(self, "instrument", None):
+            frappe.delete_doc("Instrument", self.instrument.name, force=True, ignore_permissions=True)
+        super().tearDown()
+
+    def _make_user(self, email: str, roles: list[str]) -> 'Document':
+        if frappe.db.exists("User", email):
+            user = frappe.get_doc("User", email)
+        else:
+            user = frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": "ISN",
+                    "last_name": "Security",
+                    "send_welcome_email": 0,
+                }
+            )
+            user.insert(ignore_permissions=True)
+        user.add_roles(*roles)
+        return user
+
+    def test_attach_requires_permissions_and_logs_denial(self):
+        """Customers without write permission must be denied with a security log."""
+        customer = self._make_user("isn-security-client@example.com", ["Customer"])
+        frappe.set_user(customer.name)
+
+        security_logger = MagicMock()
+        audit_logger = MagicMock()
+
+        def _logger(channel: str):
+            if channel == "instrument_profile_security":
+                return security_logger
+            if channel == "instrument_profile_audit":
+                return audit_logger
+            return MagicMock()
+
+        frappe.cache().delete(f"find_similar_rate_limit:{customer.name}")
+
+        with patch(
+            "repair_portal.instrument_profile.doctype.instrument_serial_number.instrument_serial_number.frappe.logger",
+            new=_logger,
+        ):
+            isn_doc = frappe.get_doc("Instrument Serial Number", self.isn.name)
+            with self.assertRaises(frappe.PermissionError):
+                isn_doc.attach_to_instrument(self.instrument.name)
+
+        self.assertTrue(security_logger.info.called)
+        payload = security_logger.info.call_args[0][0]
+        self.assertEqual(payload["status"], "denied")
+        self.assertEqual(payload["extras"].get("reason"), "no_isn_write_permission")
+        self.assertFalse(audit_logger.info.called)
+
+    def test_attach_success_emits_audit_log(self):
+        """Administrators attaching an instrument should generate an audit trail."""
+        frappe.set_user("Administrator")
+
+        security_logger = MagicMock()
+        audit_logger = MagicMock()
+
+        def _logger(channel: str):
+            if channel == "instrument_profile_security":
+                return security_logger
+            if channel == "instrument_profile_audit":
+                return audit_logger
+            return MagicMock()
+
+        isn_doc = frappe.get_doc("Instrument Serial Number", self.isn.name)
+
+        with patch(
+            "repair_portal.instrument_profile.doctype.instrument_serial_number.instrument_serial_number.frappe.logger",
+            new=_logger,
+        ):
+            result = isn_doc.attach_to_instrument(self.instrument.name)
+
+        self.assertEqual(result["instrument"], self.instrument.name)
+        self.assertTrue(audit_logger.info.called)
+        payload = audit_logger.info.call_args[0][0]
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(payload["extras"].get("target_instrument"), self.instrument.name)
+
+    def test_find_similar_rate_limit_enforced(self):
+        """Burst find_similar calls should raise and emit a rate-limit log entry."""
+        frappe.set_user("Administrator")
+        security_logger = MagicMock()
+
+        def _logger(channel: str):
+            if channel == "instrument_profile_security":
+                return security_logger
+            return MagicMock()
+
+        cache_key = f"find_similar_rate_limit:{frappe.session.user}"
+        frappe.cache().delete(cache_key)
+
+        isn_doc = frappe.get_doc("Instrument Serial Number", self.isn.name)
+
+        with patch(
+            "repair_portal.instrument_profile.doctype.instrument_serial_number.instrument_serial_number.frappe.logger",
+            new=_logger,
+        ):
+            for _ in range(11):
+                isn_doc.find_similar()
+
+            with self.assertRaises(frappe.ValidationError):
+                isn_doc.find_similar()
+
+        self.assertTrue(security_logger.info.called)
+        payload = security_logger.info.call_args_list[-1][0][0]
+        self.assertEqual(payload["status"], "rate_limited")
+        self.assertEqual(payload["extras"].get("limit"), 10)

--- a/repair_portal/instrument_profile/services/test_profile_sync_security.py
+++ b/repair_portal/instrument_profile/services/test_profile_sync_security.py
@@ -1,0 +1,170 @@
+"""Security regression tests for Instrument Profile sync services."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch, call
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from repair_portal.instrument_profile.services import profile_sync
+
+if TYPE_CHECKING:
+    from frappe.model.document import Document
+
+
+class TestProfileSyncSecurity(FrappeTestCase):
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+        if not frappe.db.exists("Brand", "Security Sync Brand"):
+            frappe.get_doc(
+                {
+                    "doctype": "Brand",
+                    "brand": "Security Sync Brand",
+                }
+            ).insert(ignore_permissions=True)
+
+        self.instrument = frappe.get_doc(
+            {
+                "doctype": "Instrument",
+                "serial_no": f"SEC-SYNC-{frappe.generate_hash(length=5)}",
+                "brand": "Security Sync Brand",
+                "clarinet_type": "Bb Clarinet",
+                "current_status": "Active",
+            }
+        )
+        self.instrument.insert(ignore_permissions=True)
+
+        self.profile = frappe.get_doc(
+            {
+                "doctype": "Instrument Profile",
+                "instrument": self.instrument.name,
+                "serial_no": "stale",
+                "brand": "Outdated",
+            }
+        )
+        self.profile.insert(ignore_permissions=True)
+
+        self.addCleanup(lambda: frappe.set_user("Administrator"))
+
+    def tearDown(self):
+        if getattr(self, "profile", None):
+            frappe.delete_doc("Instrument Profile", self.profile.name, force=True, ignore_permissions=True)
+        if getattr(self, "instrument", None):
+            frappe.delete_doc("Instrument", self.instrument.name, force=True, ignore_permissions=True)
+        super().tearDown()
+
+    def _make_user(self, email: str, roles: list[str]) -> 'Document':
+        if frappe.db.exists("User", email):
+            user = frappe.get_doc("User", email)
+        else:
+            user = frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": "Profile",
+                    "last_name": "Security",
+                    "send_welcome_email": 0,
+                }
+            )
+            user.insert(ignore_permissions=True)
+        user.add_roles(*roles)
+        return user
+
+    def test_sync_now_denied_without_profile_permission(self):
+        """Users without write permission must be blocked and logged."""
+        user = self._make_user("profile-sync-client@example.com", ["Customer"])
+        frappe.set_user(user.name)
+
+        security_logger = MagicMock()
+
+        def _logger(channel: str):
+            if channel == "instrument_profile_security":
+                return security_logger
+            return MagicMock()
+
+        with patch(
+            "repair_portal.instrument_profile.services.profile_sync.frappe.logger",
+            new=_logger,
+        ):
+            with self.assertRaises(frappe.PermissionError):
+                profile_sync.sync_now(profile=self.profile.name)
+
+        payload = security_logger.info.call_args[0][0]
+        self.assertEqual(payload["status"], "denied")
+        self.assertEqual(payload["extras"].get("reason"), "no_profile_write_permission")
+
+    def test_sync_now_denied_without_instrument_permission(self):
+        """Instrument read checks must be enforced and logged."""
+        user = self._make_user("profile-sync-client2@example.com", ["Customer"])
+        frappe.set_user(user.name)
+
+        security_logger = MagicMock()
+
+        def _logger(channel: str):
+            if channel == "instrument_profile_security":
+                return security_logger
+            return MagicMock()
+
+        with patch(
+            "repair_portal.instrument_profile.services.profile_sync.frappe.logger",
+            new=_logger,
+        ):
+            with self.assertRaises(frappe.PermissionError):
+                profile_sync.sync_now(instrument=self.instrument.name)
+
+        payload = security_logger.info.call_args[0][0]
+        self.assertEqual(payload["doctype"], "Instrument")
+        self.assertEqual(payload["status"], "denied")
+        self.assertEqual(payload["extras"].get("reason"), "no_instrument_read_permission")
+
+    def test_sync_now_batches_db_updates_and_logs_job_event(self):
+        """Successful sync writes once and emits a job log entry."""
+        frappe.set_user("Administrator")
+
+        # Ensure there are differences so an update occurs
+        frappe.db.set_value(
+            "Instrument",
+            self.instrument.name,
+            {
+                "brand": "Security Sync Brand",
+                "clarinet_type": "Bb Clarinet",
+                "current_status": "Active",
+            },
+        )
+
+        security_logger = MagicMock()
+        job_logger = MagicMock()
+
+        def _logger(channel: str):
+            if channel == "instrument_profile_security":
+                return security_logger
+            if channel == "instrument_profile_jobs":
+                return job_logger
+            return MagicMock()
+
+        with patch(
+            "repair_portal.instrument_profile.services.profile_sync.frappe.logger",
+            new=_logger,
+        ), patch(
+            "repair_portal.instrument_profile.services.profile_sync.frappe.db.set_value",
+            wraps=frappe.db.set_value,
+        ) as patched_set_value:
+            result = profile_sync.sync_now(profile=self.profile.name)
+
+        self.assertEqual(result["profile"], self.profile.name)
+        self.assertTrue(job_logger.info.called)
+        job_payload = job_logger.info.call_args_list[-1][0][0]
+        self.assertEqual(job_payload["status"], "success")
+        self.assertEqual(job_payload["extras"].get("instrument"), self.instrument.name)
+
+        calls = [
+            call for call in patched_set_value.call_args_list if call[0][0] == "Instrument Profile"
+        ]
+        self.assertEqual(len(calls), 1)
+        updated_fields = calls[0][0][2]
+        self.assertIsInstance(updated_fields, dict)
+        self.assertGreaterEqual(len(updated_fields.keys()), 3)

--- a/repair_portal/mypy.ini
+++ b/repair_portal/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.10
+warn_unused_ignores = True
+ignore_missing_imports = True
+show_error_codes = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False


### PR DESCRIPTION
## Summary
- add dedicated security regression tests for instrument serial numbers, profile sync services, and warranty throttling helpers
- harden instrument serial number and profile sync services with structured security/audit logging and batched profile updates
- introduce per-recipient daily throttling for warranty emails and extend documentation plus tooling with mypy/bandit hooks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e528fc07248328ba3d012cdc88e48a